### PR TITLE
Add instructions for using "jest-junit" in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Then simply run:
 jest
 ```
 
+For your Continuous Integration you can simply do:
+```shell
+jest --ci --reporters=default --reporters=jest-junit
+```
+
 ## Usage as testResultsProcessor
 In your jest config add the following entry:
 ```JSON


### PR DESCRIPTION
Support for testResultsProcessor is deprecated.

Credits to [this comment](https://github.com/jest-community/jest-junit/issues/56#issuecomment-402009645) by @mattbrictson.