### PR TITLE
Add `outputDirectory` and `outputName`;

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jest --ci --testResultsProcessor="jest-junit"
 
 ## Configuration
 
-`jest-junit` offers seven configurations based on environment variables or a `jest-junit` key defined in `package.json` or a reporter option. 
+`jest-junit` offers seven configurations based on environment variables or a `jest-junit` key defined in `package.json` or a reporter option.
 Environement variable and package.json configuration should be **strings**.
 Reporter options should also be strings exception for suiteNameTemplate, classNameTemplate, titleNameTemplate that can also accept a function returning a string.
 
@@ -59,6 +59,8 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 |--|--|--|--|
 | `JEST_SUITE_NAME` | `name` attribute of `<testsuites>` | `"jest tests"` | N/A
 | `JEST_JUNIT_OUTPUT` | File path to save the output. | `"./junit.xml"` | N/A
+| `JEST_JUNIT_OUTPUT_DIR` | Directory to save the output. | `null` | N/A
+| `JEST_JUNIT_OUTPUT_NAME` | File name for the output. | `"./junit.xml"` | N/A
 | `JEST_JUNIT_SUITE_NAME` | Template string for `name` attribute of the `<testsuite>`. | `"{title}"` | `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_CLASSNAME` | Template string for the `classname` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_TITLE` | Template string for the `name` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
@@ -79,7 +81,8 @@ Or you can also define a `jest-junit` key in your `package.json`.  All are **str
   ...
   "jest-junit": {
     "suiteName": "jest tests",
-    "output": "./junit.xml",
+    "outputDirectory": ".",
+    "outputName": "./junit.xml",
     "classNameTemplate": "{classname}-{title}",
     "titleTemplate": "{classname}-{title}",
     "ancestorSeparator": " › ",

--- a/constants/index.js
+++ b/constants/index.js
@@ -6,6 +6,8 @@ module.exports = {
   ENVIRONMENT_CONFIG_MAP: {
     JEST_SUITE_NAME: 'suiteName',
     JEST_JUNIT_OUTPUT: 'output',
+    JEST_JUNIT_OUTPUT_DIR: 'outputDirectory',
+    JEST_JUNIT_OUTPUT_NAME: 'outputName',
     JEST_JUNIT_CLASSNAME: 'classNameTemplate',
     JEST_JUNIT_SUITE_NAME: 'suiteNameTemplate',
     JEST_JUNIT_TITLE: 'titleTemplate',
@@ -15,6 +17,8 @@ module.exports = {
   DEFAULT_OPTIONS: {
     suiteName: 'jest tests',
     output: path.join(process.cwd(), './junit.xml'),
+    outputDirectory: null,
+    outputName: 'junit.xml',
     classNameTemplate: '{classname} {title}',
     suiteNameTemplate: '{title}',
     titleTemplate: '{classname} {title}',

--- a/index.js
+++ b/index.js
@@ -16,11 +16,13 @@ const processor = (report, reporterOptions = {}) => {
 
   const jsonResults = buildJsonResults(report, fs.realpathSync(process.cwd()), options);
 
+  // Set output to use new outputDirectory and fallback on original output
+  const output = options.outputDirectory === null ? options.output :  path.join(options.outputDirectory, options.outputName);
   // Ensure output path exists
-  mkdirp.sync(path.dirname(options.output));
+  mkdirp.sync(path.dirname(output));
 
   // Write data to file
-  fs.writeFileSync(options.output, xml(jsonResults, { indent: '  '}));
+  fs.writeFileSync(output, xml(jsonResults, { indent: '  '}));
 
   // Jest 18 compatibility
   return report;


### PR DESCRIPTION
Resolves #61 

*Introduces*
- `JEST_JUNIT_OUTPUT_DIR`:`outputDirectory` - Directory where xml file will be stored
- `JEST_JUNIT_OUTPUT_NAME`:`outputName` - File name of the test results. (Default `junit.xml`)

This change is introduced in a backwards compatible manner. Personally I think that we should recommend users to move to the new configuration options and depreciate the `output`/`JEST_JUNIT_OUTPUT` options.