### PR TITLE
Allow <rootDir> placeholder to be used in the output option.

### DIFF
--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -40,8 +40,8 @@ describe('replace <rootDir>', () => {
 
     // Result of replaceRootDirInOutput will also contain the drive letter and path slashes (different format depending on OS).
     // So instead assert that the rootDir is in the result and the placeholder (<rootDir>) is not.
-    expect(newOutput.indexOf(rootDir) !== 0).toBe(true);
-    expect(newOutput.indexOf('<rootDir>') === -1).toBe(true);
+    expect(newOutput).toContain(rootDir);
+    expect(newOutput).not.toContain('<rootDir>');
   });
 
   it('should not replace when output has no <rootDir>', () => {

--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -30,3 +30,34 @@ describe('getOptions', () => {
 
   });
 });
+
+describe('replace <rootDir>', () => {
+  it('should replace <rootDir> in output path', () => {
+    const rootDir = 'testRootDir';
+    const outputPath = '<rootDir>/test/result/output.xml';
+
+    const newOutput = getOptions.replaceRootDirInOutput(rootDir, outputPath);
+
+    // Result of replaceRootDirInOutput will also contain the drive letter and path slashes (different format depending on OS).
+    // So instead assert that the rootDir is in the result and the placeholder (<rootDir>) is not.
+    expect(newOutput.indexOf(rootDir) !== 0).toBe(true);
+    expect(newOutput.indexOf('<rootDir>') === -1).toBe(true);
+  });
+
+  it('should not replace when output has no <rootDir>', () => {
+    const rootDir = 'testRootDir';
+    const outputPath = 'testDir/test/result/output.xml';
+
+    const newOutput = getOptions.replaceRootDirInOutput(rootDir, outputPath);
+
+    expect(newOutput).toBe(outputPath);
+  });
+
+  it('should not replace when rootDir is null', () => {
+    const outputPath = 'testDir/test/result/output.xml';
+
+    const newOutput = getOptions.replaceRootDirInOutput(null, outputPath);
+
+    expect(newOutput).toBe(outputPath);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const jestValidate = require('jest-validate');
 const buildJsonResults = require('./utils/buildJsonResults');
 const getOptions = require('./utils/getOptions');
 
-const processor = (report, reporterOptions = {}) => {
+const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   // If jest-junit is used as a reporter allow for reporter options
   // to be used. Env and package.json will override.
   const options = getOptions.options(reporterOptions);
@@ -18,11 +18,14 @@ const processor = (report, reporterOptions = {}) => {
 
   // Set output to use new outputDirectory and fallback on original output
   const output = options.outputDirectory === null ? options.output :  path.join(options.outputDirectory, options.outputName);
+
+  const finalOutput = getOptions.replaceRootDirInOutput(jestRootDir, output);
+
   // Ensure output path exists
-  mkdirp.sync(path.dirname(output));
+  mkdirp.sync(path.dirname(finalOutput));
 
   // Write data to file
-  fs.writeFileSync(output, xml(jsonResults, { indent: '  '}));
+  fs.writeFileSync(finalOutput, xml(jsonResults, { indent: '  ' }));
 
   // Jest 18 compatibility
   return report;
@@ -62,7 +65,7 @@ function JestJUnit (globalConfig, options) {
   this._options = options;
 
   this.onRunComplete = (contexts, results) => {
-    processor(results, this._options);
+    processor(results, this._options, this._globalConfig.rootDir);
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
+    "jest-config": "^23.6.0",
     "jest-validate": "^23.0.1",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^4.0.0",

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 
 const constants = require('../constants/index');
 
+const { replaceRootDirInPath } = require('jest-config');
+
 function getEnvOptions() {
   const options = {};
 
@@ -44,10 +46,15 @@ function getAppOptions(pathToResolve) {
   return {};
 }
 
+function replaceRootDirInOutput(rootDir, output) {
+  return rootDir !== null ? replaceRootDirInPath(rootDir, output) : output;
+}
+
 module.exports = {
   options: (reporterOptions = {}) => {
     return Object.assign({}, constants.DEFAULT_OPTIONS, reporterOptions, getAppOptions(process.cwd()), getEnvOptions());
   },
   getAppOptions: getAppOptions,
-  getEnvOptions: getEnvOptions
+  getEnvOptions: getEnvOptions,
+  replaceRootDirInOutput: replaceRootDirInOutput
 };


### PR DESCRIPTION
Resolves [#49](https://github.com/jest-community/jest-junit/issues/49)

Changes to allow `<rootDir>` placeholder to be used in the `output` option. Useful when `jest-junit` is used in a monorepo environment, where you want each project to have its own test result. In a monorepo jest `rootDir` will be the path of whatever the project under test is.

Had to add `jest-config` as a dependency in order to access the same function that jest uses to replace the `<rootDir>` placeholder. Thought this would be a better option than writing a custom replacer, as it keeps it consistent with jest.

Thanks