### PR TITLE
Fix to output relative path correctly

### DIFF
--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -6,28 +6,28 @@ const constants = require('../constants/index');
 describe('buildJsonResults', () => {
   it('should contain number of tests in testSuite', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '', constants.DEFAULT_OPTIONS);
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/', constants.DEFAULT_OPTIONS);
 
     expect(jsonResults.testsuites[1].testsuite[0]._attr.tests).toBe(1);
   });
 
   it('should contain number of tests in testSuites', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '', constants.DEFAULT_OPTIONS);
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/', constants.DEFAULT_OPTIONS);
 
     expect(jsonResults.testsuites[0]._attr.tests).toBe(1);
   });
 
   it('should return the proper name from ancestorTitles when usePathForSuiteName is "false"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '', constants.DEFAULT_OPTIONS);
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/', constants.DEFAULT_OPTIONS);
 
     expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('foo');
   });
 
   it('should return the proper filename when suiteNameTemplate is "{filename}"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         suiteNameTemplate: "{filename}"
       }));
@@ -36,7 +36,7 @@ describe('buildJsonResults', () => {
 
   it('should support suiteNameTemplate as function', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         suiteNameTemplate: (vars) => {
           return 'function called with vars: ' + Object.keys(vars).join(', ');
@@ -48,7 +48,7 @@ describe('buildJsonResults', () => {
 
   it('should return the proper filename when classNameTemplate is "{filename}"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         classNameTemplate: "{filename}"
       }));
@@ -57,7 +57,7 @@ describe('buildJsonResults', () => {
 
   it('should support return the function result when classNameTemplate is a function', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         classNameTemplate: (vars) => {
           return 'function called with vars: ' + Object.keys(vars).join(', ');
@@ -69,38 +69,38 @@ describe('buildJsonResults', () => {
 
   it('should return the proper filepath when titleTemplate is "{filepath}"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         titleTemplate: "{filepath}"
       }));
-    expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.name).toBe('/path/to/test/__tests__/foo.test.js');
+    expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.name).toBe('path/to/test/__tests__/foo.test.js');
   });
 
   it('should return the proper filepath when suiteNameTemplate is "{filepath}" and usePathForSuiteName is "false"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         suiteNameTemplate: "{filepath}"
       }));
-    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('/path/to/test/__tests__/foo.test.js');
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('path/to/test/__tests__/foo.test.js');
   });
 
   it('should return the proper name from ancestorTitles when suiteNameTemplate is set to "{title}" and usePathForSuiteName is "true"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         usePathForSuiteName: "true"
       }));
-    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('/path/to/test/__tests__/foo.test.js');
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('path/to/test/__tests__/foo.test.js');
   });
 
   it('should return the proper name from testFilePath when usePathForSuiteName is "true"; no appDirectory set', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         usePathForSuiteName: "true"
       }));
-    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('/path/to/test/__tests__/foo.test.js');
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('path/to/test/__tests__/foo.test.js');
   });
 
   it('should return the proper name from testFilePath when usePathForSuiteName is "true"; with appDirectory set', () => {
@@ -109,19 +109,19 @@ describe('buildJsonResults', () => {
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         usePathForSuiteName: "true"
       }));
-    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('/__tests__/foo.test.js');
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.name).toBe('__tests__/foo.test.js');
   });
 
   it('should return the proper classname when ancestorSeparator is default', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS));
     expect(jsonResults.testsuites[1].testsuite[1].testcase[0]._attr.classname).toBe('foo baz should bar');
   });
 
   it('should return the proper classname when ancestorSeparator is customized', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    const jsonResults = buildJsonResults(noFailingTestsReport, '',
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         ancestorSeparator: " › "
       }));
@@ -146,7 +146,7 @@ describe('buildJsonResults', () => {
     const startDate = new Date(multiProjectNoFailingTestsReport.startTime);
     spyOn(Date, 'now').and.returnValue(startDate.getTime() + 1234);
 
-    const jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '',
+    const jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         suiteNameTemplate: "{displayName}-foo",
         titleTemplate: "{displayName}-foo"

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -67,7 +67,7 @@ module.exports = function (report, appDirectory, options) {
     }
 
     // Build variables for suite name
-    const filepath = suite.testFilePath.replace(appDirectory, '');
+    const filepath = path.relative(appDirectory, suite.testFilePath);
     const filename = path.basename(filepath);
     const suiteTitle = suite.testResults[0].ancestorTitles[0];
     const displayName = suite.displayName;


### PR DESCRIPTION
Currently `filepath` starts with `/` but in most case, it's a wrong path.

## How to reproduce

```
git clone https://github.com/jest-community/jest-junit
cd jest-junit
yarn install
JEST_JUNIT_SUITE_NAME='{filepath}' yarn jest --env node integration-tests/reporter/__tests__/simple.test.js --reporters=default --reporters=$PWD/index.js
```

## Before

```xml
<testsuites name="jest tests" tests="1" failures="0" time="0.336">
  <testsuite name="/integration-tests/reporter/__tests__/simple.test.js" errors="0" failures="0" skipped="0" timestamp="2018-12-18T10:54:15" time="0.216" tests="1">
    <testcase classname="foo should pass" name="foo should pass" time="0.003">
    </testcase>
  </testsuite>
</testsuites>
```

## After

```xml
<testsuites name="jest tests" tests="1" failures="0" time="0.364">
  <testsuite name="integration-tests/reporter/__tests__/simple.test.js" errors="0" failures="0" skipped="0" timestamp="2018-12-18T10:55:11" time="0.241" tests="1">
    <testcase classname="foo should pass" name="foo should pass" time="0.003">
    </testcase>
  </testsuite>
</testsuites>
```