### PR TITLE
Add file attr

### DIFF
--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -29,6 +29,7 @@ Object {
             Object {
               "_attr": Object {
                 "classname": "a thing should foo",
+                "file": "path/to/project1/__tests__/test1.test.js",
                 "name": "project1-foo",
                 "time": 0.003,
               },
@@ -55,6 +56,7 @@ Object {
             Object {
               "_attr": Object {
                 "classname": "another thing should foo",
+                "file": "path/to/project2/__tests__/test2.test.js",
                 "name": "project2-foo",
                 "time": 0.001,
               },

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -119,7 +119,8 @@ module.exports = function (report, appDirectory, options) {
           _attr: {
             classname: replaceVars(options.classNameTemplate, testVariables),
             name: replaceVars(options.titleTemplate, testVariables),
-            time: tc.duration / 1000
+            time: tc.duration / 1000,
+            file: filepath
           }
         }]
       };


### PR DESCRIPTION
Ref: https://github.com/jest-community/jest-junit/pull/70
This PR depends on https://github.com/jest-community/jest-junit/pull/70

@palmerj3 

> Before I merge could you please just provide a rationale for this change? What problem(s) is it solving on your end?

I'd like to add `file` attr because some tools (ex. circleci) show file path if the report has this attr.
I thought to fix the path and to add attr can be split but actually, this PR is what I need.

https://github.com/sj26/rspec_junit_formatter/pull/22