### PR TITLE
Add console support when jest-junit is used as a reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-junit",
-  "version": "6.4.0",
+  "version": "7.0.0",
   "description": "A jest reporter that generates junit xml files",
   "main": "index.js",
   "repository": "https://github.com/jest-community/jest-junit",


### PR DESCRIPTION
Fixes https://github.com/jest-community/jest-junit/issues/45

Jest made a breaking change which set console to undefined for onRunComplete for reporters in order to address a memory leak.

This change aggregates console output from onTestResult and adds it to the report.