### PR TITLE
[feat] Remove support for old 'output' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | Environment Variable Name | Reporter Config Name| Description | Default | Possible Injection Values
 |--|--|--|--|--|
 | `JEST_SUITE_NAME` | `suiteName` | `name` attribute of `<testsuites>` | `"jest tests"` | N/A
-| `JEST_JUNIT_OUTPUT` | `output` | File path to save the output. | `"./junit.xml"` | N/A
-| `JEST_JUNIT_OUTPUT_DIR` | `outputDirectory` | Directory to save the output. | `null` | N/A
-| `JEST_JUNIT_OUTPUT_NAME` | `outputName` | File name for the output. | `"./junit.xml"` | N/A
+| `JEST_JUNIT_OUTPUT_DIR` | `outputDirectory` | Directory to save the output. | `process.cwd()` | N/A
+| `JEST_JUNIT_OUTPUT_NAME` | `outputName` | File name for the output. | `"junit.xml"` | N/A
 | `JEST_JUNIT_SUITE_NAME` | `suiteNameTemplate` | Template string for `name` attribute of the `<testsuite>`. | `"{title}"` | `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_CLASSNAME` | `classNameTemplate` | Template string for the `classname` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_TITLE` | `titleTemplate` | Template string for the `name` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
@@ -73,7 +72,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 You can configure these options via the command line as seen below:
 
 ```shell
-JEST_SUITE_NAME="Jest JUnit Unit Tests" JEST_JUNIT_OUTPUT="./artifacts/junit.xml" jest
+JEST_SUITE_NAME="Jest JUnit Unit Tests" JEST_JUNIT_OUTPUT_DIR="./artifacts" jest
 ```
 
 Or you can also define a `jest-junit` key in your `package.json`.  All are **string** values.
@@ -84,7 +83,7 @@ Or you can also define a `jest-junit` key in your `package.json`.  All are **str
   "jest-junit": {
     "suiteName": "jest tests",
     "outputDirectory": ".",
-    "outputName": "./junit.xml",
+    "outputName": "junit.xml",
     "classNameTemplate": "{classname}-{title}",
     "titleTemplate": "{classname}-{title}",
     "ancestorSeparator": " › ",

--- a/constants/index.js
+++ b/constants/index.js
@@ -5,7 +5,6 @@ const path = require('path');
 module.exports = {
   ENVIRONMENT_CONFIG_MAP: {
     JEST_SUITE_NAME: 'suiteName',
-    JEST_JUNIT_OUTPUT: 'output',
     JEST_JUNIT_OUTPUT_DIR: 'outputDirectory',
     JEST_JUNIT_OUTPUT_NAME: 'outputName',
     JEST_JUNIT_CLASSNAME: 'classNameTemplate',
@@ -18,8 +17,7 @@ module.exports = {
   },
   DEFAULT_OPTIONS: {
     suiteName: 'jest tests',
-    output: path.join(process.cwd(), './junit.xml'),
-    outputDirectory: null,
+    outputDirectory: process.cwd(),
     outputName: 'junit.xml',
     classNameTemplate: '{classname} {title}',
     suiteNameTemplate: '{title}',

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   const jsonResults = buildJsonResults(report, fs.realpathSync(process.cwd()), options);
 
   // Set output to use new outputDirectory and fallback on original output
-  const output = options.outputDirectory === null ? options.output :  path.join(options.outputDirectory, options.outputName);
+  const output = path.join(options.outputDirectory, options.outputName);
 
   const finalOutput = getOptions.replaceRootDirInOutput(jestRootDir, output);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-junit",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "A jest reporter that generates junit xml files",
   "main": "index.js",
   "repository": "https://github.com/jest-community/jest-junit",


### PR DESCRIPTION
Breaking change

Remove the `output` setting, and change the default of `outputDirectory`
from `null` to `process.cwd()`.

This will cause the defaults for `outputDirectory` and `outputName` to
be joined together to the same as the old `output` value, with the added
benefit of them being overrideable separately.

Fixes #100