### PR TITLE
bug: Ensure executionTime() never returns negative

### DIFF
--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -31,6 +31,9 @@ const replaceVars = function (strOrFunc, variables) {
 };
 
 const executionTime = function (startTime, endTime) {
+  if (endTime < startTime) {
+    return 0;
+  }
   return (endTime - startTime) / 1000;
 }
 


### PR DESCRIPTION
There is a case that  `suite.perfStats.end` is 0 or less than the ` suite.perfStats.start` value causing negative values to be reported in the JUnit xml which breaks the junit parsers in Jenkins.