### PR TITLE
Issue-97 shorten console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_ANCESTOR_SEPARATOR` | `ancestorSeparator` | Character(s) used to join the `describe` blocks. | `" "` | N/A
 | `JEST_JUNIT_ADD_FILE_ATTRIBUTE` | `addFileAttribute` | Add file attribute to the output. This config is primarily for Circle CI. This setting provides richer details but may break on other CI platforms. | `false` | N/A
 | `JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT` | `includeConsoleOutput` | Adds console output to any testSuite that generates stdout during a test run. | `false` | N/A
+| `JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT` | `includeShortConsoleOutput` | Adds short console output (only message value) to any testSuite that generates stdout during a test run. | `false` | N/A
 | `JEST_USE_PATH_FOR_SUITE_NAME` | `usePathForSuiteName` | **DEPRECATED. Use `suiteNameTemplate` instead.** Use file path as the `name` attribute of `<testsuite>` | `"false"` | N/A
 
 

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -189,4 +189,24 @@ describe('buildJsonResults', () => {
 
     expect(jsonResults.testsuites[1].testsuite[1]['system-out']).not.toBeDefined();
   });
+  
+  it('should show short console output if includeShortConsoleOutput is true', () => {
+    const reportWithShortConsoleOutput = require('../__mocks__/test-with-console-output.json');
+    const jsonResults = buildJsonResults(reportWithShortConsoleOutput, '/',
+      Object.assign({}, constants.DEFAULT_OPTIONS, {
+        includeShortConsoleOutput: "true"
+      }));
+
+    expect(jsonResults.testsuites[1].testsuite[1]['system-out']._cdata).toEqual("[\n  \"I am bar\",\n  \"Some output here from a lib\"\n]");
+  });
+
+  it('should NOT show short console output if includeShortConsoleOutput is not set or false', () => {
+    const reportWithShortConsoleOutput = require('../__mocks__/test-with-console-output.json');
+    const jsonResults = buildJsonResults(reportWithShortConsoleOutput, '/',
+      Object.assign({}, constants.DEFAULT_OPTIONS, {
+        includeShortConsoleOutput: "false"
+      }));
+      
+    expect(jsonResults.testsuites[1].testsuite[1]['system-out']).not.toBeDefined();
+  });
 });

--- a/constants/index.js
+++ b/constants/index.js
@@ -12,6 +12,7 @@ module.exports = {
     JEST_JUNIT_ANCESTOR_SEPARATOR: 'ancestorSeparator',
     JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'addFileAttribute',
     JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT: 'includeConsoleOutput',
+    JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT: 'includeShortConsoleOutput',
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
   },
   DEFAULT_OPTIONS: {
@@ -26,6 +27,7 @@ module.exports = {
     usePathForSuiteName: 'false',
     addFileAttribute: 'false',
     includeConsoleOutput: 'false',
+    includeShortConsoleOutput: 'false'
   },
   CLASSNAME_VAR: 'classname',
   FILENAME_VAR: 'filename',

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -114,6 +114,20 @@ module.exports = function (report, appDirectory, options) {
 
       testSuite.testsuite.push(testSuiteConsole);
     }
+    
+    // Write short stdout console output if available
+    if (options.includeShortConsoleOutput === 'true' && suite.console && suite.console.length) {
+      // Extract and then Stringify the console message value
+      // Easier this way because formatting in a readable way is tough with XML
+      // And this can be parsed more easily
+      let testSuiteConsole = {
+        'system-out': {
+          _cdata: JSON.stringify(suite.console.map(item => item.message), null, 2)
+        }
+      };
+
+      testSuite.testsuite.push(testSuiteConsole);
+    }
 
     // Iterate through test cases
     suite.testResults.forEach((tc) => {


### PR DESCRIPTION
This PR resolves [Issue-97](https://github.com/jest-community/jest-junit/issues/97)

- Added a new flag `includeShortConsoleOutput: "false"`
- When this flag is set to true `includeShortConsoleOutput: "true"` only message value is displayed in test result output
- Added 2 new tests
- Confirmed all the tests pass locally.
- Tested the PR locally by overwriting the jest-junit files in node_modules
