### PR TITLE
Remove mkdirp and replace with internal util

### DIFF
--- a/__tests__/makeDir.test.js
+++ b/__tests__/makeDir.test.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const makeDirRecursive = require('../utils/makeDir').makeDirRecursive;
+
+describe('makeDir', () => {
+  it ('should create non-nested directory', () => {
+    const testPath = path.join('.', 'foo');
+
+    rimraf.sync(testPath);
+
+    const result = makeDirRecursive(testPath);
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(testPath)).toBe(true);
+
+    rimraf.sync(testPath);
+  });
+
+  it ('should create a nested directory', () => {
+    const testPath = path.join('.', 'foo', 'foo2');
+
+    rimraf.sync(testPath);
+
+    const result = makeDirRecursive(testPath);
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(testPath)).toBe(true);
+
+    rimraf.sync(path.join('.', 'foo'));
+  });
+
+  it ('should return true if path already exists', () => {
+    const testPath = path.join('.', 'foo');
+
+    rimraf.sync(testPath);
+
+    const result = makeDirRecursive(testPath);
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(testPath)).toBe(true);
+
+
+    const result2 = makeDirRecursive(testPath);
+    expect(result).toBe(true);
+    expect(fs.existsSync(testPath)).toBe(true);
+
+    rimraf.sync(testPath);
+  });
+
+  it ('should support a lot of nesting', () => {
+    const rootPath = path.join('.', 'foo');
+    const testPath = path.join(rootPath, 'foo2', 'foo3', 'foo4', 'foo5', 'foo6', 'foo7', 'foo8', 'foo9');
+
+    rimraf.sync(rootPath);
+
+    const result = makeDirRecursive(testPath);
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(testPath)).toBe(true);
+
+    rimraf.sync(rootPath);
+  });
+});

--- a/__tests__/makeDir.test.js
+++ b/__tests__/makeDir.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
-const makeDirRecursive = require('../utils/makeDir').makeDirRecursive;
+const { makeDirRecursive } = require('../utils/makeDir');
 
 describe('makeDir', () => {
   it ('should create non-nested directory', () => {

--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-jest.mock('mkdirp', () => {
+jest.mock('../utils/makeDir', () => {
   return Object.assign(
     {},
-    require.requireActual('mkdirp'),
+    require.requireActual('../utils/makeDir'),
     {
-      sync: jest.fn()
+      makeDirRecursive: jest.fn()
     }
   )
 });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const xml = require('xml');
-const mkdirp = require('mkdirp');
+const makeDirRecursive = require('./utils/makeDir').makeDirRecursive;
 const fs = require('fs');
 const path = require('path');
 const jestValidate = require('jest-validate');
@@ -31,7 +31,7 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   const finalOutput = getOptions.replaceRootDirInOutput(jestRootDir, output);
 
   // Ensure output path exists
-  mkdirp.sync(path.dirname(finalOutput));
+  makeDirRecursive(path.dirname(finalOutput));
 
   // Write data to file
   fs.writeFileSync(finalOutput, xml(jsonResults, { indent: '  ', declaration: true }));

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   },
   "dependencies": {
     "jest-validate": "^24.9.0",
-    "mkdirp": "^0.5.1",
     "strip-ansi": "^5.2.0",
     "uuid": "^3.3.3",
     "xml": "^1.0.1"
   },
   "devDependencies": {
     "jest": "^24.9.0",
-    "libxmljs": "^0.19.7"
+    "libxmljs": "^0.19.7",
+    "rimraf": "^3.0.2"
   }
 }

--- a/utils/makeDir.js
+++ b/utils/makeDir.js
@@ -2,14 +2,20 @@ const fs = require('fs');
 const path = require('path');
 
 const makeDirRecursive = (pathToCreate) => {
+  try {
+    path.parse(pathToCreate);
+  } catch (e) {
+    return false;
+  }
+
   const dirs = pathToCreate.split(path.sep);
 
   let workingPath = '';
 
-  while (dirs.length > 0 && fs.existsSync(pathToCreate) === false) {
+  while (dirs.length > 0 && !fs.existsSync(pathToCreate)) {
     workingPath = path.join(workingPath, dirs.shift());
 
-    if (fs.existsSync(workingPath) === false) {
+    if (!fs.existsSync(pathToCreate)) {
       try {
         fs.mkdirSync(workingPath);
       } catch (e) {

--- a/utils/makeDir.js
+++ b/utils/makeDir.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const makeDirRecursive = (pathToCreate) => {
+  const dirs = pathToCreate.split(path.sep);
+
+  let workingPath = '';
+
+  while (dirs.length > 0 && fs.existsSync(pathToCreate) === false) {
+    workingPath = path.join(workingPath, dirs.shift());
+
+    if (fs.existsSync(workingPath) === false) {
+      try {
+        fs.mkdirSync(workingPath);
+      } catch (e) {
+      }
+    }
+  }
+
+  return fs.existsSync(pathToCreate);
+};
+
+module.exports = {
+  makeDirRecursive
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,6 +2237,11 @@ minimist@^1.1.1, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -2265,12 +2270,19 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
+  dependencies:
+    minimist "^1.2.5"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2883,6 +2895,13 @@ rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
Addresses the security vulnerability and keeps support for node 8.x