### PR TITLE
Added {suitename} as possible injection value for classNameTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_OUTPUT_NAME` | `outputName` | File name for the output. | `"junit.xml"` | N/A
 | `JEST_JUNIT_UNIQUE_OUTPUT_NAME` | `uniqueOutputName` | Create unique file name for the output `junit-${uuid}.xml`, overrides `outputName` | `false` | N/A
 | `JEST_JUNIT_SUITE_NAME` | `suiteNameTemplate` | Template string for `name` attribute of the `<testsuite>`. | `"{title}"` | `{title}`, `{filepath}`, `{filename}`, `{displayName}`
-| `JEST_JUNIT_CLASSNAME` | `classNameTemplate` | Template string for the `classname` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
+| `JEST_JUNIT_CLASSNAME` | `classNameTemplate` | Template string for the `classname` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{suitename}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_TITLE` | `titleTemplate` | Template string for the `name` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_ANCESTOR_SEPARATOR` | `ancestorSeparator` | Character(s) used to join the `describe` blocks. | `" "` | N/A
 | `JEST_JUNIT_ADD_FILE_ATTRIBUTE` | `addFileAttribute` | Add file attribute to the output. This config is primarily for Circle CI. This setting provides richer details but may break on other CI platforms. Must be a string. | `"false"` | N/A

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -46,6 +46,36 @@ describe('buildJsonResults', () => {
       .toBe('function called with vars: filepath, filename, title, displayName');
   });
 
+  it('should return the proper classname when classNameTemplate is "{classname}"', () => {
+    const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          classNameTemplate: "{classname}"
+        }));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('foo baz');
+  });
+
+  it('should return the proper title when classNameTemplate is "{title}"', () => {
+    const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          classNameTemplate: "{title}"
+        }));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('should bar');
+  });
+
+  it('should return the proper filepath when classNameTemplate is "{filepath}"', () => {
+    const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          classNameTemplate: "{filepath}"
+        }));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('path/to/test/__tests__/foo.test.js');
+  });
+
   it('should return the proper filename when classNameTemplate is "{filename}"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
     const jsonResults = buildJsonResults(noFailingTestsReport, '/',
@@ -54,6 +84,27 @@ describe('buildJsonResults', () => {
       }));
 
     expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('foo.test.js');
+  });
+
+  it('should return the proper displayName when classNameTemplate is {displayName}', () => {
+    const multiProjectNoFailingTestsReport = require('../__mocks__/multi-project-no-failing-tests.json');
+
+    const jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '/',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          classNameTemplate: "{displayName}"
+        }));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('project1');
+  });
+
+  it('should return the proper suitename when classNameTemplate is "{suitename}"', () => {
+    const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
+    const jsonResults = buildJsonResults(noFailingTestsReport, '/',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          classNameTemplate: "{suitename}"
+        }));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname).toBe('foo');
   });
 
   it('should support return the function result when classNameTemplate is a function', () => {
@@ -65,7 +116,7 @@ describe('buildJsonResults', () => {
         }
       }));
     expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.classname)
-      .toBe('function called with vars: filepath, filename, classname, title, displayName');
+      .toBe('function called with vars: filepath, filename, suitename, classname, title, displayName');
   });
 
   it('should return the proper filepath when titleTemplate is "{filepath}"', () => {

--- a/constants/index.js
+++ b/constants/index.js
@@ -31,6 +31,7 @@ module.exports = {
     includeShortConsoleOutput: 'false',
     testSuitePropertiesFile: 'junitProperties.js'
   },
+  SUITENAME_VAR: 'suitename',
   CLASSNAME_VAR: 'classname',
   FILENAME_VAR: 'filename',
   FILEPATH_VAR: 'filepath',

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   Represents the status of the test runs
 
   Expected input and workflow documentation here:
-  https://facebook.github.io/jest/docs/configuration.html#testresultsprocessor-string
+  https://jestjs.io/docs/en/configuration#testresultsprocessor-string
 
   Intended output (junit XML) documentation here:
   http://help.catchsoftware.com/display/ET/JUnit+Format

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -166,6 +166,7 @@ module.exports = function (report, appDirectory, options) {
       let testVariables = {};
       testVariables[constants.FILEPATH_VAR] = filepath;
       testVariables[constants.FILENAME_VAR] = filename;
+      testVariables[constants.SUITENAME_VAR] = suiteTitle;
       testVariables[constants.CLASSNAME_VAR] = classname;
       testVariables[constants.TITLE_VAR] = testTitle;
       testVariables[constants.DISPLAY_NAME_VAR] = displayName;


### PR DESCRIPTION
Allows the user to create a `classNameTemplate` which contains `{suitename}`

This was the main case I was looking for, but could also be done for `suiteNameTemplate` and `titleNameTemplate` if it seems helpful.

Also added a few tests for `classNameTemplate` and corrected a link in `index.js`