### PR TITLE
Fix system-out location in generated junit xml

### DIFF
--- a/__tests__/lib/setupTests.js
+++ b/__tests__/lib/setupTests.js
@@ -7,7 +7,7 @@ const schemaPath = path.join(__dirname, 'junit.xsd');
 const schemaStr = fs.readFileSync(schemaPath);
 const schema = libxmljs.parseXmlString(schemaStr);
 
-expect.extend({
+global.expect.extend({
   toConvertToXmlAndPassXsd(jsonResults) {
     const xmlStr = xml(jsonResults, { indent: '  '});
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,5 @@ module.exports = {
     "<rootDir>/integration-tests/testResultsProcessor/",
     "<rootDir>/integration-tests/reporter/"
   ],
-  setupFilesAfterEnv: ["<rootDir>/__tests__/lib/setupTests.js"],
   reporters: ['default', '.']
 };

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -105,34 +105,6 @@ module.exports = function (report, appDirectory, options) {
     jsonResults.testsuites[0]._attr.failures += suite.numFailingTests;
     jsonResults.testsuites[0]._attr.tests += suiteNumTests;
 
-    // Write stdout console output if available
-    if (options.includeConsoleOutput === 'true' && suite.console && suite.console.length) {
-      // Stringify the entire console object
-      // Easier this way because formatting in a readable way is tough with XML
-      // And this can be parsed more easily
-      let testSuiteConsole = {
-        'system-out': {
-          _cdata: JSON.stringify(suite.console, null, 2)
-        }
-      };
-
-      testSuite.testsuite.push(testSuiteConsole);
-    }
-
-    // Write short stdout console output if available
-    if (options.includeShortConsoleOutput === 'true' && suite.console && suite.console.length) {
-      // Extract and then Stringify the console message value
-      // Easier this way because formatting in a readable way is tough with XML
-      // And this can be parsed more easily
-      let testSuiteConsole = {
-        'system-out': {
-          _cdata: JSON.stringify(suite.console.map(item => item.message), null, 2)
-        }
-      };
-
-      testSuite.testsuite.push(testSuiteConsole);
-    }
-
     if (!ignoreSuitePropertiesCheck) {
       let junitSuiteProperties = require(junitSuitePropertiesFilePath)(suite);
 
@@ -201,6 +173,34 @@ module.exports = function (report, appDirectory, options) {
         testCase.testcase.push({
           skipped: {}
         });
+      }
+
+      // Write stdout console output if available
+      if (options.includeConsoleOutput === 'true' && suite.console && suite.console.length) {
+        // Stringify the entire console object
+        // Easier this way because formatting in a readable way is tough with XML
+        // And this can be parsed more easily
+        let testSuiteConsole = {
+          'system-out': {
+            _cdata: JSON.stringify(suite.console, null, 2)
+          }
+        };
+
+        testCase.testcase.push(testSuiteConsole);
+      }
+
+      // Write short stdout console output if available
+      if (options.includeShortConsoleOutput === 'true' && suite.console && suite.console.length) {
+        // Extract and then Stringify the console message value
+        // Easier this way because formatting in a readable way is tough with XML
+        // And this can be parsed more easily
+        let testSuiteConsole = {
+          'system-out': {
+            _cdata: JSON.stringify(suite.console.map(item => item.message), null, 2)
+          }
+        };
+
+        testCase.testcase.push(testSuiteConsole);
       }
 
       testSuite.testsuite.push(testCase);


### PR DESCRIPTION
Added xsd validation for every unit test and this determined that system-out tag was being added underneath testsuite instead of testcase where it belongs.

This PR fixes that problem.

A major version bump will occur after this is merged since this may be a breaking change for some.