### PR TITLE
Report no results as error

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_ADD_FILE_ATTRIBUTE` | `addFileAttribute` | Add file attribute to the output. This config is primarily for Circle CI. This setting provides richer details but may break on other CI platforms. Must be a string. | `"false"` | N/A
 | `JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT` | `includeConsoleOutput` | Adds console output to any testSuite that generates stdout during a test run. | `false` | N/A
 | `JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT` | `includeShortConsoleOutput` | Adds short console output (only message value) to any testSuite that generates stdout during a test run. | `false` | N/A
-| `JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR` | `reportNoResultsAsError` | Reports test files that failed to execute altogether due to a syntax or typescript compilation error, as a suite with a single test with `error` result. | `false` | N/A
+| `JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR` | `reportTestSuiteErrors` | Reports test suites that failed to execute altogether as `error`. _Note:_ since the suite name cannot be determined from files that fail to load, it will default to file path.| `false` | N/A
 | `JEST_USE_PATH_FOR_SUITE_NAME` | `usePathForSuiteName` | **DEPRECATED. Use `suiteNameTemplate` instead.** Use file path as the `name` attribute of `<testsuite>` | `"false"` | N/A
 
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_ADD_FILE_ATTRIBUTE` | `addFileAttribute` | Add file attribute to the output. This config is primarily for Circle CI. This setting provides richer details but may break on other CI platforms. Must be a string. | `"false"` | N/A
 | `JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT` | `includeConsoleOutput` | Adds console output to any testSuite that generates stdout during a test run. | `false` | N/A
 | `JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT` | `includeShortConsoleOutput` | Adds short console output (only message value) to any testSuite that generates stdout during a test run. | `false` | N/A
+| `JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR` | `reportNoResultsAsError` | Reports test files that failed to execute altogether due to a syntax or typescript compilation error, as a suite with a single test with `error` result. | `false` | N/A
 | `JEST_USE_PATH_FOR_SUITE_NAME` | `usePathForSuiteName` | **DEPRECATED. Use `suiteNameTemplate` instead.** Use file path as the `name` attribute of `<testsuite>` | `"false"` | N/A
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_ADD_FILE_ATTRIBUTE` | `addFileAttribute` | Add file attribute to the output. This config is primarily for Circle CI. This setting provides richer details but may break on other CI platforms. Must be a string. | `"false"` | N/A
 | `JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT` | `includeConsoleOutput` | Adds console output to any testSuite that generates stdout during a test run. | `false` | N/A
 | `JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT` | `includeShortConsoleOutput` | Adds short console output (only message value) to any testSuite that generates stdout during a test run. | `false` | N/A
-| `JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR` | `reportTestSuiteErrors` | Reports test suites that failed to execute altogether as `error`. _Note:_ since the suite name cannot be determined from files that fail to load, it will default to file path.| `false` | N/A
+| `JEST_JUNIT_REPORT_TEST_SUITE_ERRORS` | `reportTestSuiteErrors` | Reports test suites that failed to execute altogether as `error`. _Note:_ since the suite name cannot be determined from files that fail to load, it will default to file path.| `false` | N/A
 | `JEST_USE_PATH_FOR_SUITE_NAME` | `usePathForSuiteName` | **DEPRECATED. Use `suiteNameTemplate` instead.** Use file path as the `name` attribute of `<testsuite>` | `"false"` | N/A
 
 

--- a/__mocks__/empty-suite.json
+++ b/__mocks__/empty-suite.json
@@ -1,0 +1,65 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 0,
+  "numPassedTests": 0,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 1,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 0,
+  "openHandles": [],
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1601808216222,
+  "success": false,
+  "testResults": [
+    {
+      "failureMessage": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    Your test suite must contain at least one test.\n\n      \u001b[2mat onResult (\u001b[22mnode_modules/@jest/core/build/TestScheduler.js\u001b[2m:175:18)\u001b[22m\n      \u001b[2mat testRunner.on (\u001b[22mnode_modules/@jest/core/build/TestScheduler.js\u001b[2m:304:17)\u001b[22m\n      \u001b[2mat Promise.all.staticListeners.map (\u001b[22mnode_modules/emittery/index.js\u001b[2m:260:13)\u001b[22m\n          at Array.map (<anonymous>)\n      \u001b[2mat Emittery.Typed.emit (\u001b[22mnode_modules/emittery/index.js\u001b[2m:258:23)\u001b[22m\n",
+      "leaks": false,
+      "numFailingTests": 0,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "numTodoTests": 0,
+      "openHandles": [],
+      "perfStats": {
+        "end": 0,
+        "runtime": 0,
+        "slow": false,
+        "start": 0
+      },
+      "skipped": false,
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "uncheckedKeys": [],
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testExecError": {
+        "message": "Your test suite must contain at least one test.",
+        "stack": "Error: Your test suite must contain at least one test.\n    at onResult ../mpl-modules/test/docker/node_modules/@jest/core/build/TestScheduler.js:175:18)\n    at testRunner.on ../mpl-modules/test/docker/node_modules/@jest/core/build/TestScheduler.js:304:17)\n    at Promise.all.staticListeners.map ../mpl-modules/test/docker/node_modules/emittery/index.js:260:13)\n    at Array.map (<anonymous>)\n    at Emittery.Typed.emit ../mpl-modules/test/docker/node_modules/emittery/index.js:258:23)"
+      },
+      "testFilePath": "/path/to/spec/test.spec.ts",
+      "testResults": []
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__mocks__/failing-compilation.json
+++ b/__mocks__/failing-compilation.json
@@ -1,0 +1,102 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 0,
+  "numPassedTests": 0,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 1,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 0,
+  "openHandles": [],
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": false,
+  "testResults": [
+    {
+      "displayName": "",
+      "failureMessage": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):\n    \u001b[96mspec/test.spec.ts\u001b[0m:\u001b[93m10\u001b[0m:\u001b[93m35\u001b[0m - \u001b[91merror\u001b[0m\u001b[90m TS2339: \u001b[0mProperty 'hello' does not exist on type 'HelloScreamer'.\n\n    \u001b[7m10\u001b[0m         const screamed = screamer.hello();\n    \u001b[7m  \u001b[0m \u001b[91m                                  ~~~~~\u001b[0m\n",
+      "leaks": false,
+      "numFailingTests": 0,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "numTodoTests": 0,
+      "openHandles": [],
+      "perfStats": {
+        "end": 1499904221109,
+        "start": 1499904215586
+      },
+      "skipped": false,
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "sourceMaps": {},
+      "testExecError": "spec/test.spec.ts:10:35 - error TS2339: Property 'hello' does not exist on type 'HelloScreamer\n\n      10         const screamed = screamer.hello();\n~~~~~",
+      "testFilePath": "/path/to/spec/test.spec.ts",
+      "testResults": [],
+      "coverage": {
+      }
+    },
+    {
+      "console": [],
+      "failureMessage": null,
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1518274351347,
+        "start": 1518274351274
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0,
+        "uncheckedKeys": []
+      },
+      "testFilePath": "/path/to/project2/__tests__/test2.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "another thing"
+          ],
+          "duration": 1,
+          "failureMessages": [],
+          "fullName": "another thing should foo",
+          "location": null,
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should foo"
+        }
+      ],
+      "sourceMaps": {},
+      "skipped": false,
+      "displayName": "project2",
+      "leaks": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__mocks__/failing-import.json
+++ b/__mocks__/failing-import.json
@@ -1,0 +1,63 @@
+{
+  "numFailedTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 1,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 2,
+  "numTotalTests": 1,
+  "openHandles": [],
+  "snapshot": {
+    "added": 0,
+    "didUpdate": false,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesRemovedList": [],
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "uncheckedKeysByFile": [],
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1601544556519,
+  "success": false,
+  "testResults": [
+    {
+      "displayName": "",
+      "failureMessage": "  \u001b[1m● \u001b[22mTest suite failed to run\n\n    Cannot find module './mult' from 'mul.test.js'\n\n    \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39m\u001b[36mconst\u001b[39m mul \u001b[33m=\u001b[39m require(\u001b[32m'./mult'\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n    \u001b[0m \u001b[90m   | \u001b[39m\u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m\n    \u001b[0m \u001b[90m 2 | \u001b[39m\u001b[0m\n    \u001b[0m \u001b[90m 3 | \u001b[39mtest(\u001b[32m'multplies 2 * 3 to equal 6'\u001b[39m\u001b[33m,\u001b[39m () \u001b[33m=>\u001b[39m {\u001b[0m\n    \u001b[0m \u001b[90m 4 | \u001b[39m    expect(mul(\u001b[35m2\u001b[39m\u001b[33m,\u001b[39m \u001b[35m3\u001b[39m))\u001b[33m.\u001b[39mtoBe(\u001b[35m6\u001b[39m)\u001b[33m;\u001b[39m\u001b[0m\n\n      \u001b[2mat Resolver.resolveModule (\u001b[22mnode_modules/jest-resolve/build/index.js\u001b[2m:259:17)\u001b[22m\n      \u001b[2mat Object.<anonymous> (\u001b[22m\u001b[0m\u001b[36msrc/mul.test.js\u001b[39m\u001b[0m\u001b[2m:1:1)\u001b[22m\n",
+      "leaks": false,
+      "numFailingTests": 0,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "numTodoTests": 0,
+      "openHandles": [],
+      "perfStats": {
+        "end": 0,
+        "start": 0
+      },
+      "skipped": false,
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "uncheckedKeys": [],
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testExecError": {
+        "code": "MODULE_NOT_FOUND"
+      },
+      "testFilePath": "/path/to/spec/test.spec.ts",
+      "testResults": []
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "testsuites": Array [
     Object {
       "_attr": Object {
+        "errors": 0,
         "failures": 0,
         "name": "jest tests",
         "tests": 2,

--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -41,7 +41,7 @@ Object {
             Object {
               "_attr": Object {
                 "classname": "a thing should foo",
-                "name": "project1-foo",
+                "name": "project1-bar",
                 "time": 0.003,
               },
             },
@@ -79,7 +79,7 @@ Object {
             Object {
               "_attr": Object {
                 "classname": "another thing should foo",
-                "name": "project2-foo",
+                "name": "project2-bar",
                 "time": 0.001,
               },
             },

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -137,7 +137,7 @@ describe('buildJsonResults', () => {
   it('should report no results as error', () => {
     const failingTestsReport = require('../__mocks__/failing-compilation.json');
 
-    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
           reportTestSuiteErrors: "true"
         }));
@@ -162,7 +162,7 @@ describe('buildJsonResults', () => {
   it('should report failureMessage if testExecErrorNotSet ', () => {
     const failingTestsReport = require('../__mocks__/failing-import.json');
 
-    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
           reportTestSuiteErrors: "true"
         }));
@@ -176,7 +176,7 @@ describe('buildJsonResults', () => {
   it('should honor templates when test has errors', () => {
     const failingTestsReport = require('../__mocks__/failing-compilation.json');
 
-    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
           reportTestSuiteErrors: "true",
           suiteNameTemplate: "{displayName}-foo",

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -139,7 +139,7 @@ describe('buildJsonResults', () => {
 
     const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
-          reportNoResultsAsError: "true"
+          reportTestSuiteErrors: "true"
         }));
 
     const totals = jsonResults.testsuites[0]._attr;
@@ -164,7 +164,7 @@ describe('buildJsonResults', () => {
 
     const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
-          reportNoResultsAsError: "true"
+          reportTestSuiteErrors: "true"
         }));
 
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
@@ -178,7 +178,7 @@ describe('buildJsonResults', () => {
 
     const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
         Object.assign({}, constants.DEFAULT_OPTIONS, {
-          reportNoResultsAsError: "true",
+          reportTestSuiteErrors: "true",
           suiteNameTemplate: "{displayName}-foo",
           titleTemplate: "{title}-bar"
         }));

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -134,6 +134,43 @@ describe('buildJsonResults', () => {
       .toBe('function called with vars: filepath, filename, suitename, classname, title, displayName');
   });
 
+  it('should report no results as error', () => {
+    const failingTestsReport = require('../__mocks__/failing-compilation.json');
+
+    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          reportNoResultsAsError: "true"
+        }));
+
+    const totals = jsonResults.testsuites[0]._attr;
+    expect(totals.tests).toEqual(1);
+    expect(totals.errors).toEqual(1);
+    expect(totals.failures).toEqual(0);
+
+    const suiteResult = jsonResults.testsuites[1].testsuite[0]._attr;
+    expect(suiteResult.name).toEqual('../spec/test.spec.ts')
+    expect(suiteResult.errors).toEqual(1);
+    expect(suiteResult.tests).toEqual(0);
+
+    const errorSuite = jsonResults.testsuites[1].testsuite[2];
+    expect(errorSuite.testcase[0]._attr.name).toEqual(`Error while trying to run test file ${suiteResult.name}`);
+    expect(errorSuite.testcase[1].error).toContain("Property 'hello' does not exist");
+
+  });
+
+  it('should honor templates when test has errors', () => {
+    const failingTestsReport = require('../__mocks__/failing-compilation.json');
+
+    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          reportNoResultsAsError: "true",
+          suiteNameTemplate: "{displayName}-foo",
+          titleTemplate: "{title}-bar"
+        }));
+
+    expect(jsonResults.testsuites[2].testsuite[2].testcase[0]._attr.name).toEqual('should foo-bar');
+  });
+
   it('should return the proper filepath when titleTemplate is "{filepath}"', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
     jsonResults = buildJsonResults(noFailingTestsReport, '/',

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -216,7 +216,7 @@ describe('buildJsonResults', () => {
     jsonResults = buildJsonResults(multiProjectNoFailingTestsReport, '/',
       Object.assign({}, constants.DEFAULT_OPTIONS, {
         suiteNameTemplate: "{displayName}-foo",
-        titleTemplate: "{displayName}-foo"
+        titleTemplate: "{displayName}-bar"
       }));
 
     expect(jsonResults).toMatchSnapshot();

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -158,6 +158,19 @@ describe('buildJsonResults', () => {
 
   });
 
+  it('should report failureMessage if testExecErrorNotSet ', () => {
+    const failingTestsReport = require('../__mocks__/failing-import.json');
+
+    const jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          reportNoResultsAsError: "true"
+        }));
+
+    const errorSuite = jsonResults.testsuites[1].testsuite[2];
+    expect(errorSuite.testcase[0]._attr.name).toEqual(`Error while trying to run test file ../spec/test.spec.ts`);
+    expect(errorSuite.testcase[1].error).toContain("Cannot find module './mult'");
+  });
+
   it('should honor templates when test has errors', () => {
     const failingTestsReport = require('../__mocks__/failing-compilation.json');
 

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -159,7 +159,7 @@ describe('buildJsonResults', () => {
 
   });
 
-  it('should report failureMessage if testExecErrorNotSet ', () => {
+  it('should report failureMessage if testExecErrorNotSet', () => {
     const failingTestsReport = require('../__mocks__/failing-import.json');
 
     jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
@@ -171,6 +171,20 @@ describe('buildJsonResults', () => {
     expect(errorSuite.testcase[0]._attr.name).toEqual('../spec/test.spec.ts');
     expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
     expect(errorSuite.testcase[1].error).toContain("Cannot find module './mult'");
+  });
+
+  it('should report empty suites as error', () => {
+    const failingTestsReport = require('../__mocks__/empty-suite.json');
+
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          reportTestSuiteErrors: "true"
+        }));
+
+    const errorSuite = jsonResults.testsuites[1].testsuite[2];
+    expect(errorSuite.testcase[0]._attr.name).toEqual('../spec/test.spec.ts');
+    expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
+    expect(errorSuite.testcase[1].error).toContain("Your test suite must contain at least one test");
   });
 
   it('should honor templates when test has errors', () => {

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -153,7 +153,8 @@ describe('buildJsonResults', () => {
     expect(suiteResult.tests).toEqual(0);
 
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
-    expect(errorSuite.testcase[0]._attr.name).toEqual(`Error while trying to run test file ${suiteResult.name}`);
+    expect(errorSuite.testcase[0]._attr.name).toEqual(suiteResult.name);
+    expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
     expect(errorSuite.testcase[1].error).toContain("Property 'hello' does not exist");
 
   });
@@ -167,7 +168,8 @@ describe('buildJsonResults', () => {
         }));
 
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
-    expect(errorSuite.testcase[0]._attr.name).toEqual(`Error while trying to run test file ../spec/test.spec.ts`);
+    expect(errorSuite.testcase[0]._attr.name).toEqual('../spec/test.spec.ts');
+    expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
     expect(errorSuite.testcase[1].error).toContain("Cannot find module './mult'");
   });
 

--- a/constants/index.js
+++ b/constants/index.js
@@ -13,6 +13,7 @@ module.exports = {
     JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'addFileAttribute',
     JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT: 'includeConsoleOutput',
     JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT: 'includeShortConsoleOutput',
+    JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR: 'reportNoResultsAsError',
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
     JEST_JUNIT_TEST_SUITE_PROPERTIES_JSON_FILE: 'testSuitePropertiesFile'
   },
@@ -29,6 +30,7 @@ module.exports = {
     addFileAttribute: 'false',
     includeConsoleOutput: 'false',
     includeShortConsoleOutput: 'false',
+    reportNoResultsAsError: 'false',
     testSuitePropertiesFile: 'junitProperties.js'
   },
   SUITENAME_VAR: 'suitename',

--- a/constants/index.js
+++ b/constants/index.js
@@ -13,7 +13,7 @@ module.exports = {
     JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'addFileAttribute',
     JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT: 'includeConsoleOutput',
     JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT: 'includeShortConsoleOutput',
-    JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR: 'reportNoResultsAsError',
+    JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR: 'reportTestSuiteErrors',
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
     JEST_JUNIT_TEST_SUITE_PROPERTIES_JSON_FILE: 'testSuitePropertiesFile'
   },
@@ -30,7 +30,7 @@ module.exports = {
     addFileAttribute: 'false',
     includeConsoleOutput: 'false',
     includeShortConsoleOutput: 'false',
-    reportNoResultsAsError: 'false',
+    reportTestSuiteErrors: 'false',
     testSuitePropertiesFile: 'junitProperties.js'
   },
   SUITENAME_VAR: 'suitename',

--- a/constants/index.js
+++ b/constants/index.js
@@ -13,7 +13,7 @@ module.exports = {
     JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'addFileAttribute',
     JEST_JUNIT_INCLUDE_CONSOLE_OUTPUT: 'includeConsoleOutput',
     JEST_JUNIT_INCLUDE_SHORT_CONSOLE_OUTPUT: 'includeShortConsoleOutput',
-    JEST_JUNIT_REPORT_NO_RESULTS_AS_ERROR: 'reportTestSuiteErrors',
+    JEST_JUNIT_REPORT_TEST_SUITE_ERRORS: 'reportTestSuiteErrors',
     JEST_USE_PATH_FOR_SUITE_NAME: 'usePathForSuiteName',
     JEST_JUNIT_TEST_SUITE_PROPERTIES_JSON_FILE: 'testSuitePropertiesFile'
   },

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -66,9 +66,11 @@ module.exports = function (report, appDirectory, options) {
   // Iterate through outer testResults (test suites)
   report.testResults.forEach((suite) => {
     // Skip empty test suites
-    if (suite.testResults.length <= 0) {
+    if (suite.testResults.length === 0) {
       return;
     }
+
+    const suiteOptions = Object.assign({}, options);
 
     // Build variables for suite name
     const filepath = path.relative(appDirectory, suite.testFilePath);
@@ -90,7 +92,7 @@ module.exports = function (report, appDirectory, options) {
     let testSuite = {
       'testsuite': [{
         _attr: {
-          name: replaceVars(options.suiteNameTemplate, suiteNameVariables),
+          name: replaceVars(suiteOptions.suiteNameTemplate, suiteNameVariables),
           errors: 0, // not supported
           failures: suite.numFailingTests,
           skipped: suite.numPendingTests,
@@ -131,7 +133,7 @@ module.exports = function (report, appDirectory, options) {
 
     // Iterate through test cases
     suite.testResults.forEach((tc) => {
-      const classname = tc.ancestorTitles.join(options.ancestorSeparator);
+      const classname = tc.ancestorTitles.join(suiteOptions.ancestorSeparator);
       const testTitle = tc.title;
 
       // Build replacement map
@@ -146,14 +148,14 @@ module.exports = function (report, appDirectory, options) {
       let testCase = {
         'testcase': [{
           _attr: {
-            classname: replaceVars(options.classNameTemplate, testVariables),
-            name: replaceVars(options.titleTemplate, testVariables),
+            classname: replaceVars(suiteOptions.classNameTemplate, testVariables),
+            name: replaceVars(suiteOptions.titleTemplate, testVariables),
             time: tc.duration / 1000
           }
         }]
       };
 
-      if (options.addFileAttribute === 'true') {
+      if (suiteOptions.addFileAttribute === 'true') {
         testCase.testcase[0]._attr.file = filepath;
       }
 
@@ -179,7 +181,7 @@ module.exports = function (report, appDirectory, options) {
     });
 
     // Write stdout console output if available
-    if (options.includeConsoleOutput === 'true' && suite.console && suite.console.length) {
+    if (suiteOptions.includeConsoleOutput === 'true' && suite.console && suite.console.length) {
       // Stringify the entire console object
       // Easier this way because formatting in a readable way is tough with XML
       // And this can be parsed more easily
@@ -193,7 +195,7 @@ module.exports = function (report, appDirectory, options) {
     }
 
     // Write short stdout console output if available
-    if (options.includeShortConsoleOutput === 'true' && suite.console && suite.console.length) {
+    if (suiteOptions.includeShortConsoleOutput === 'true' && suite.console && suite.console.length) {
       // Extract and then Stringify the console message value
       // Easier this way because formatting in a readable way is tough with XML
       // And this can be parsed more easily

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -39,6 +39,15 @@ module.exports = function (report, appDirectory, options) {
   const junitSuitePropertiesFilePath = path.join(process.cwd(), options.testSuitePropertiesFile);
   let ignoreSuitePropertiesCheck = !fs.existsSync(junitSuitePropertiesFilePath);
 
+  // If the usePathForSuiteName option is true and the
+  // suiteNameTemplate value is set to the default, overrides
+  // the suiteNameTemplate.
+  if (options.usePathForSuiteName === 'true' &&
+      options.suiteNameTemplate === toTemplateTag(constants.TITLE_VAR)) {
+
+    options.suiteNameTemplate = toTemplateTag(constants.FILEPATH_VAR);
+  }
+
   // Generate a single XML file for all jest tests
   let jsonResults = {
     'testsuites': [{
@@ -59,15 +68,6 @@ module.exports = function (report, appDirectory, options) {
     // Skip empty test suites
     if (suite.testResults.length <= 0) {
       return;
-    }
-
-    // If the usePathForSuiteName option is true and the
-    // suiteNameTemplate value is set to the default, overrides
-    // the suiteNameTemplate.
-    if (options.usePathForSuiteName === 'true' &&
-      options.suiteNameTemplate === toTemplateTag(constants.TITLE_VAR)) {
-
-      options.suiteNameTemplate = toTemplateTag(constants.FILEPATH_VAR);
     }
 
     // Build variables for suite name

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -79,7 +79,7 @@ module.exports = function (report, appDirectory, options) {
   // Iterate through outer testResults (test suites)
   report.testResults.forEach((suite) => {
     const noResults = suite.testResults.length === 0;
-    if (noResults && options.reportNoResultsAsError === 'false') {
+    if (noResults && options.reportTestSuiteErrors === 'false') {
       return;
     }
 

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -39,7 +39,7 @@ const addErrorTestResult = function (suite) {
     "ancestorTitles": [],
     "duration": 0,
     "failureMessages": [
-      typeof suite.testExecError === "string" ? suite.testExecError : suite.failureMessage
+      suite.failureMessage
     ],
     "numPassingAsserts": 0,
     "status": "error"

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -85,7 +85,8 @@ module.exports = function (report, appDirectory, options) {
 
     const noResultOptions = noResults ? {
       suiteNameTemplate: toTemplateTag(constants.FILEPATH_VAR),
-      titleTemplate: `Error while trying to run test file ${toTemplateTag(constants.FILEPATH_VAR)}`
+      titleTemplate: toTemplateTag(constants.FILEPATH_VAR),
+      classNameTemplate: `Test suite failed to run`
     } : {};
 
     const suiteOptions = Object.assign({}, options, noResultOptions);

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -39,7 +39,7 @@ const addErrorTestResult = function (suite) {
     "ancestorTitles": [],
     "duration": 0,
     "failureMessages": [
-      suite.testExecError
+      typeof suite.testExecError === "string" ? suite.testExecError : suite.failureMessage
     ],
     "numPassingAsserts": 0,
     "status": "error"

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -21,8 +21,6 @@ function getEnvOptions() {
 }
 
 function getAppOptions(pathToResolve) {
-  const initialPath = pathToResolve;
-
   let traversing = true;
 
   // Find nearest package.json by traversing up directories until /


### PR DESCRIPTION
# Feature proposal

Test suites that fail to run altogether due to a syntax error, failed import, compilation error, etc.  are currently not reported in the `junit.xml` results.
This is a problem in CI scenarios where the test process exit code cannot be relied on for whatever reason.

I realize this feature has been requested in #116, #46 and #26, so I'm sorry bring this up again :-)
Jest's test reports do not contain any information about the suite and tests that may be present in the test file, but failed to load. On the other hand it isn't clear to me how Jest could reliably obtain such information from an invalid javascript file.

For our use case, the fact that all error suites are reported is much more important than having stable test (suite) names.
But there may indeed be scenarios in which these priorities are reversed. In such cases users can choose not to use 
this feature.

The report when `reportNoResultsAsError` is (actively) set to `true` looks as follows:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="jest tests" tests="1" failures="0" errors="1" time="111548453.117">
    <testsuite name="../../../../../path/to/spec/test.spec.ts" errors="1" failures="0" skipped="0" timestamp="2017-07-13T00:03:35" time="5.523" tests="0">
        <properties>
            <property name="best-tester" value="Jason Palmer"/>
        </properties>
        <testcase classname="Test suite failed to run" name="../../../../../path/to/spec/test.spec.ts" time="0">
            <error>spec/test.spec.ts:10:35 - error TS2339: Property &apos;hello&apos; does not exist on type &apos;HelloScreamer

                10         const screamed = screamer.hello();
                ~~~~~</error>
        </testcase>
    </testsuite>
    <testsuite name="another thing" errors="0" failures="0" skipped="0" timestamp="2018-02-10T14:52:31" time="0.073" tests="1">
        <properties>
            <property name="best-tester" value="Jason Palmer"/>
        </properties>
        <testcase classname="another thing should foo" name="another thing should foo" time="0.001">
        </testcase>
    </testsuite>
</testsuites>
```