### PR TITLE
Make sure the "tests" key is incremented with the amount of errors

### DIFF
--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -143,14 +143,14 @@ describe('buildJsonResults', () => {
         }));
 
     const totals = jsonResults.testsuites[0]._attr;
-    expect(totals.tests).toEqual(1);
+    expect(totals.tests).toEqual(2);
     expect(totals.errors).toEqual(1);
     expect(totals.failures).toEqual(0);
 
     const suiteResult = jsonResults.testsuites[1].testsuite[0]._attr;
     expect(suiteResult.name).toEqual('../spec/test.spec.ts')
     expect(suiteResult.errors).toEqual(1);
-    expect(suiteResult.tests).toEqual(0);
+    expect(suiteResult.tests).toEqual(1);
 
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
     expect(errorSuite.testcase[0]._attr.name).toEqual(suiteResult.name);
@@ -167,6 +167,11 @@ describe('buildJsonResults', () => {
           reportTestSuiteErrors: "true"
         }));
 
+    const totals = jsonResults.testsuites[0]._attr;
+    expect(totals.tests).toEqual(1);
+    expect(totals.errors).toEqual(1);
+    expect(totals.failures).toEqual(0);
+
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
     expect(errorSuite.testcase[0]._attr.name).toEqual('../spec/test.spec.ts');
     expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
@@ -180,6 +185,11 @@ describe('buildJsonResults', () => {
         Object.assign({}, constants.DEFAULT_OPTIONS, {
           reportTestSuiteErrors: "true"
         }));
+
+    const totals = jsonResults.testsuites[0]._attr;
+    expect(totals.tests).toEqual(1);
+    expect(totals.errors).toEqual(1);
+    expect(totals.failures).toEqual(0);
 
     const errorSuite = jsonResults.testsuites[1].testsuite[2];
     expect(errorSuite.testcase[0]._attr.name).toEqual('../spec/test.spec.ts');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-junit",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "A jest reporter that generates junit xml files",
   "main": "index.js",
   "repository": "https://github.com/jest-community/jest-junit",

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -108,10 +108,10 @@ module.exports = function (report, appDirectory, options) {
     suiteNameVariables[constants.DISPLAY_NAME_VAR] = displayName;
 
     // Add <testsuite /> properties
-    const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests;
+    const suiteErrors = noResults ? 1 : 0;
+    const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests + suiteErrors;
     const suiteExecutionTime = executionTime(suite.perfStats.start, suite.perfStats.end);
 
-    const suiteErrors = noResults ? 1 : 0;
     let testSuite = {
       'testsuite': [{
         _attr: {


### PR DESCRIPTION
The error was caused by the fact that the new `testResult` was added to the `testResults` key but the changes were not reflected in any of the statistics of the suite.