### PR TITLE
Fix displayName usage in templates

### DIFF
--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -98,7 +98,9 @@ module.exports = function (report, appDirectory, options) {
     const filepath = path.relative(appDirectory, suite.testFilePath);
     const filename = path.basename(filepath);
     const suiteTitle = suite.testResults[0].ancestorTitles[0];
-    const displayName = suite.displayName;
+    const displayName = typeof suite.displayName === 'object'
+      ? suite.displayName.name
+      : suite.displayName;
 
     // Build replacement map
     let suiteNameVariables = {};


### PR DESCRIPTION
Usage of the `displayName` field was changed in Jest 24.x (see: [displayName](https://archive.jestjs.io/docs/en/24.x/configuration#displayname-string-object)) to always return an object of the format:
```js
{
    color: "...",
    name: "..."
}
```
The current implementation leads to the `displayName` template printing as `[object Object]` instead of the actual displayName value. This change fixes this by switching usage based on the property type.