### PR TITLE
Possibility of `uniqueOutputName` to use a specified prefix rather than just `junit-uuid.xml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | `JEST_JUNIT_OUTPUT_DIR` | `outputDirectory` | Directory to save the output. | `process.cwd()` | N/A
 | `JEST_JUNIT_OUTPUT_NAME` | `outputName` | File name for the output. | `"junit.xml"` | N/A
 | `JEST_JUNIT_OUTPUT_FILE` | `outputFile` | Fullpath for the output. If defined, `outputDirectory` and `outputName` will be overridden | `undefined` | N/A
-| `JEST_JUNIT_UNIQUE_OUTPUT_NAME` | `uniqueOutputName` | Create unique file name for the output `junit-${uuid}.xml`, overrides `outputName` | `false` | N/A
+| `JEST_JUNIT_UNIQUE_OUTPUT_NAME` | `uniqueOutputName` | Create unique file name for the output leveraging the `outputName` as a prefix if given `${outputName}-${uuid}.xml` or a default of `junit-${uuid}.xml` if `outputName` is not specified, overrides `outputName` | `false` | N/A
 | `JEST_JUNIT_SUITE_NAME` | `suiteNameTemplate` | Template string for `name` attribute of the `<testsuite>`. | `"{title}"` | `{title}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_CLASSNAME` | `classNameTemplate` | Template string for the `classname` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{suitename}`, `{filepath}`, `{filename}`, `{displayName}`
 | `JEST_JUNIT_TITLE` | `titleTemplate` | Template string for the `name` attribute of `<testcase>`. | `"{classname} {title}"` | `{classname}`, `{title}`, `{filepath}`, `{filename}`, `{displayName}`

--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -31,6 +31,23 @@ describe('getOptions', () => {
   });
 });
 
+describe('getUniqueOutputName', () =>{
+  const defaultPrefix = 'junit'
+
+  it(`should return default ${defaultPrefix} value if given no preferred prefix`, () => {
+    const uniqueOutput = getOptions.getUniqueOutputName()
+    expect(uniqueOutput).toContain(defaultPrefix)
+  })
+
+  it(`should return apply custom prefix value if given prefix`, () => {
+    const customPrefix = "foo"
+    const uniqueOutput = getOptions.getUniqueOutputName(customPrefix)
+    expect(uniqueOutput).not.toContain(defaultPrefix)
+    expect(uniqueOutput).toContain(customPrefix)
+  })
+
+})
+
 describe('replace <rootDir>', () => {
   it('should replace <rootDir> in output path', () => {
     const rootDir = 'testRootDir';

--- a/__tests__/lib/setupTests.js
+++ b/__tests__/lib/setupTests.js
@@ -1,13 +1,13 @@
 const xml = require('xml');
 const path = require('path');
 const fs = require('fs');
-const libxmljs = require('libxmljs');
+//const libxmljs = require('libxmljs');
 
 const schemaPath = path.join(__dirname, 'junit.xsd');
 const schemaStr = fs.readFileSync(schemaPath);
-const schema = libxmljs.parseXmlString(schemaStr);
+//const schema = libxmljs.parseXmlString(schemaStr);
 
-global.expect.extend({
+/*global.expect.extend({
   toBeCompliantJUnit(jsonResults) {
     const xmlStr = xml(jsonResults, { indent: '  '});
 
@@ -26,4 +26,4 @@ global.expect.extend({
       }
     }
   }
-});
+});*/

--- a/__tests__/lib/setupTests.js
+++ b/__tests__/lib/setupTests.js
@@ -1,13 +1,13 @@
 const xml = require('xml');
 const path = require('path');
 const fs = require('fs');
-//const libxmljs = require('libxmljs');
+const libxmljs = require('libxmljs');
 
 const schemaPath = path.join(__dirname, 'junit.xsd');
 const schemaStr = fs.readFileSync(schemaPath);
-//const schema = libxmljs.parseXmlString(schemaStr);
+const schema = libxmljs.parseXmlString(schemaStr);
 
-/*global.expect.extend({
+global.expect.extend({
   toBeCompliantJUnit(jsonResults) {
     const xmlStr = xml(jsonResults, { indent: '  '});
 
@@ -26,4 +26,4 @@ const schemaStr = fs.readFileSync(schemaPath);
       }
     }
   }
-});*/
+});

--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -47,14 +47,20 @@ describe('jest-junit', () => {
 
   it('should generate valid xml with unique name', () => {
     process.env.JEST_JUNIT_UNIQUE_OUTPUT_NAME = 'true'
+
+    const outputPrefix = "foo"
+
+    process.env.JEST_JUNIT_OUTPUT_NAME = outputPrefix;
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
     testResultProcessor(noFailingTestsReport);
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
 
+    const expectedOutputRegex = new RegExp(`${outputPrefix}-\\S+.xml`, "g")
+
     // Ensure file would have been generated
-    expect(fs.writeFileSync).toHaveBeenLastCalledWith(expect.stringMatching(/junit-\S+\.xml/), expect.any(String));
+    expect(fs.writeFileSync).toHaveBeenLastCalledWith(expect.stringMatching(expectedOutputRegex), expect.any(String));
 
     // Ensure generated file is valid xml
     const xmlDoc = libxmljs.parseXml(fs.writeFileSync.mock.calls[0][1]);

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -49,8 +49,9 @@ function replaceRootDirInOutput(rootDir, output) {
   return rootDir !== null ? replaceRootDirInPath(rootDir, output) : output;
 }
 
-function getUniqueOutputName() {
-  return `junit-${uuid()}.xml`
+function getUniqueOutputName(outputName) {
+  const outputPrefix = outputName ? outputName : 'junit'
+  return `${outputPrefix}-${uuid()}.xml`
 }
 
 module.exports = {

--- a/utils/getOutputPath.js
+++ b/utils/getOutputPath.js
@@ -6,12 +6,12 @@ module.exports = (options, jestRootDir)  => {
   let output = options.outputFile;
   if (!output) {
     // Set output to use new outputDirectory and fallback on original output
-    const outputName = (options.uniqueOutputName === 'true') ? getOptions.getUniqueOutputName() : options.outputName
+    const outputName = (options.uniqueOutputName === 'true') ? getOptions.getUniqueOutputName(options.outputName) : options.outputName
     output = getOptions.replaceRootDirInOutput(jestRootDir, options.outputDirectory);
     const finalOutput = path.join(output, outputName);
     return finalOutput;
   }
-  
+
   const finalOutput = getOptions.replaceRootDirInOutput(jestRootDir, output);
   return finalOutput;
 };


### PR DESCRIPTION
We have very descriptive outputNames by default in our project like : 

`e2e-visual-tests-win32.xml` 

Currently we have a need to generate some with a unique UUID and would want something like : 

`e2e-visual-tests-win32-UUID.xml`, unfortunately the `uniqueOutputName` has a hardcoded value : `junit-UUID.xml`



My proposal is to either leverage the outputName in tandem or to create a new option `uniqueOutputPrefix` so there is less Confusion? I'm happy to modify this PR to either.

