### PR TITLE
Failures in Test hooks like "AfterAll" don't get shown in the Junit Results

### DIFF
--- a/__mocks__/no-failing-tests-with-testexec-failure.json
+++ b/__mocks__/no-failing-tests-with-testexec-failure.json
@@ -1,0 +1,65 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 1,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": null,
+      "failureMessage": null,
+      "testExecError": "beforeAll has crashed",
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1489712747644,
+        "start": 1489712747524
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/test/__tests__/foo.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "foo",
+            "baz"
+          ],
+          "duration": 1,
+          "failureMessages": [],
+          "fullName": "foo baz should bar",
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should bar"
+        }
+      ],
+      "skipped": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -188,7 +188,7 @@ describe('buildJsonResults', () => {
         Object.assign({}, constants.DEFAULT_OPTIONS, {}));
 
     const errorSuite = jsonResults.testsuites[1].testsuite[3];
-    expect(slash(errorSuite.testcase[0]._attr.name)).toContain('Test hook execution failure');
+    expect(slash(errorSuite.testcase[0]._attr.name)).toContain('Test execution failure');
     expect(errorSuite.testcase[1].failure).toContain("beforeAll has crashed");
   });
 

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -195,6 +195,31 @@ describe('buildJsonResults', () => {
     expect(errorSuite.testcase[1].error).toContain("Your test suite must contain at least one test");
   });
 
+    it('should include a failing testcase from a suite with passing testcases but  a failure from "testExec" ', () => {
+    const failingTestsReport = require('../__mocks__/no-failing-tests-with-testexec-failure.json');
+
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {}));
+
+    const errorSuite = jsonResults.testsuites[1].testsuite[3];
+    expect(slash(errorSuite.testcase[0]._attr.name)).toContain('Test hook execution failure');
+    expect(errorSuite.testcase[1].failure).toContain("beforeAll has crashed");
+  });
+
+  it('should report empty suites as error', () => {
+    const failingTestsReport = require('../__mocks__/empty-suite.json');
+
+    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {
+          reportTestSuiteErrors: "true"
+        }));
+
+    const errorSuite = jsonResults.testsuites[1].testsuite[2];
+    expect(slash(errorSuite.testcase[0]._attr.name)).toEqual('../spec/test.spec.ts');
+    expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
+    expect(errorSuite.testcase[1].error).toContain("Your test suite must contain at least one test");
+  });
+
   it('should honor templates when test has errors', () => {
     const failingTestsReport = require('../__mocks__/failing-compilation.json');
 

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -181,20 +181,6 @@ describe('buildJsonResults', () => {
     expect(errorSuite.testcase[1].error).toContain("Cannot find module './mult'");
   });
 
-  it('should report empty suites as error', () => {
-    const failingTestsReport = require('../__mocks__/empty-suite.json');
-
-    jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
-        Object.assign({}, constants.DEFAULT_OPTIONS, {
-          reportTestSuiteErrors: "true"
-        }));
-
-    const errorSuite = jsonResults.testsuites[1].testsuite[2];
-    expect(slash(errorSuite.testcase[0]._attr.name)).toEqual('../spec/test.spec.ts');
-    expect(errorSuite.testcase[0]._attr.classname).toEqual('Test suite failed to run');
-    expect(errorSuite.testcase[1].error).toContain("Your test suite must contain at least one test");
-  });
-
     it('should include a failing testcase from a suite with passing testcases but  a failure from "testExec" ', () => {
     const failingTestsReport = require('../__mocks__/no-failing-tests-with-testexec-failure.json');
 

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -11,6 +11,9 @@ const toTemplateTag = function (varName) {
   return "{" + varName + "}";
 }
 
+const testFailureStatus = 'failed';
+const testErrorStatus = 'error';
+
 // Replaces var using a template string or a function.
 // When strOrFunc is a template string replaces {varname} with the value from the variables map.
 // When strOrFunc is a function it returns the result of the function to which the variables are passed.
@@ -64,12 +67,12 @@ const generateTestCase = function(tc, filepath, filename, suiteTitle, displayNam
 
   // Write out all failure messages as <failure> tags
   // Nested underneath <testcase> tag
-  if (tc.status === 'failed'|| tc.status === 'error') {
+  if (tc.status === testFailureStatus || tc.status === testErrorStatus) {
     const failureMessages = options.noStackTrace === 'true' && tc.failureDetails ?
         tc.failureDetails.map(detail => detail.message) : tc.failureMessages;
 
     failureMessages.forEach((failure) => {
-      const tagName = tc.status === 'failed' ? 'failure': 'error'
+      const tagName = tc.status === testFailureStatus ? 'failure': testErrorStatus
       testCase.testcase.push({
         [tagName]: stripAnsi(failure)
       });
@@ -95,7 +98,7 @@ const addErrorTestResult = function (suite) {
       suite.failureMessage
     ],
     "numPassingAsserts": 0,
-    "status": "error"
+    "status": testErrorStatus
   })
 }
 
@@ -214,7 +217,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
     }
 
     if (suite.numFailingTests === 0 && suite.testExecError !== undefined) {
-      const fakeTC = {status: "failure", failureMessages:[JSON.stringify(suite.testExecError)], classname: undefined, title:"Test execution failure"}
+      const fakeTC = {status: testFailureStatus, failureMessages:[JSON.stringify(suite.testExecError)], classname: undefined, title:"Test execution failure"}
       const testCase = generateTestCase(fakeTC, filepath, filename, suiteTitle, displayName);
       testSuite.testsuite.push(testCase);
     }

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -223,7 +223,8 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
     });
 
     // We have all tests passed but a failure in a test hook like in the `beforeAll` method
-    if (suite.numFailingTests === 0 && suite.testExecError !== undefined) {
+    // Make sure we log them since Jest still reports the suite as failed
+    if (suite.testExecError !== undefined) {
       const fakeTC = {
         status: testFailureStatus,
         failureMessages: [JSON.stringify(suite.testExecError)],

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -161,6 +161,44 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
       testSuite.testsuite.push(testSuitePropertyMain);
     }
 
+    if (suite.numFailingTests === 0 && suite.testExecError !== undefined) {
+      try {
+        let testVariables = {};
+        testVariables[constants.FILEPATH_VAR] = filepath;
+        testVariables[constants.FILENAME_VAR] = filename;
+        testVariables[constants.SUITENAME_VAR] = suiteTitle;
+        testVariables[constants.CLASSNAME_VAR] = "testHookFailure";
+        testVariables[constants.TITLE_VAR] = "testHookFailure";
+        testVariables[constants.DISPLAY_NAME_VAR] = displayName;
+
+        let testCase = {
+          testcase: [
+            {
+              _attr: {
+                classname: replaceVars(
+                  suiteOptions.classNameTemplate,
+                  testVariables
+                ),
+                name: replaceVars(suiteOptions.titleTemplate, testVariables),
+                file: filepath,
+                time: 0,
+              },
+            },
+          ],
+        };
+
+        testCase.testcase.push({
+          failure: stripAnsi(JSON.stringify(suite.testExecError)),
+        });
+
+        testSuite.testsuite.push(testCase);
+      } catch (error) {
+        console.log(
+          `Unable to add junit result for test hook failure : ${suite.testExecError}`
+        );
+      }
+    }
+
     // Iterate through test cases
     suite.testResults.forEach((tc) => {
       const classname = tc.ancestorTitles.join(suiteOptions.ancestorSeparator);

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -229,7 +229,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
         status: testFailureStatus,
         failureMessages: [JSON.stringify(suite.testExecError)],
         classname: undefined,
-        title: "Test hook execution failure",
+        title: "Test execution failure: could be caused by test hooks like 'afterAll'.",
         ancestorTitles: [""],
         duration: 0,
       };

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -216,9 +216,22 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
       testSuite.testsuite.push(testSuitePropertyMain);
     }
 
+    // We have all tests passed but a failure in a test hook like in the `beforeAll` method
     if (suite.numFailingTests === 0 && suite.testExecError !== undefined) {
-      const fakeTC = {status: testFailureStatus, failureMessages:[JSON.stringify(suite.testExecError)], classname: undefined, title:"Test execution failure"}
-      const testCase = generateTestCase(fakeTC, filepath, filename, suiteTitle, displayName);
+      const fakeTC = {
+        status: testFailureStatus,
+        failureMessages: [JSON.stringify(suite.testExecError)],
+        classname: undefined,
+        title: "Test hook execution failure",
+        duration: 0,
+      };
+      const testCase = generateTestCase(
+        fakeTC,
+        filepath,
+        filename,
+        suiteTitle,
+        displayName
+      );
       testSuite.testsuite.push(testCase);
     }
 


### PR DESCRIPTION

# Problem statement
There are situations where a  testcase passes correctly but the afterAll block can fail, this currently leads to a `Junit` output that gives us a false sense that the test fully passes while Jest itself reports back the suite fails.

## Repro
Here is a simple repro :
```ts
describe("Smoke Test", () => {
  afterAll(async () => {
    expect(1).toBe(2);
  });

  it("the truth", async () => {
    expect(1).toBe(1);
  });
});
```
Produces a JUNIT of
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="jest tests" tests="1" failures="0" errors="0" time="87.038">
  <testsuite name="Smoke Test" errors="0" failures="0" skipped="0" timestamp="2022-04-22T17:36:58" time="86.145" tests="1">
    <testcase classname="smoke.test.ts" name="Smoke Test the truth" time="0.003">
    </testcase>
  </testsuite>
</testsuites>
```
Jest itself outputs :

```
⌛ Finished test
Test Suites: 1 failed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        86.69 s
```

From the investigation that @palmerj3  made in this thread [here](https://github.com/jest-community/jest-junit/issues/211)

The community believes we should just create a new testcase for the failure.


## Solution

Unfortunately Jest gives us the failure from the execution of the `testHook` in the `testExecError` field.

I've added an additional check if that field is not empty and then create a sort of fake `testCase` , to limit duplication I took the liberty of creating a testcase object generator function.


## Open Questions 

This is technically a bug right? so we shouldn't enable this via option but via a major version bump?



https://github.com/jest-community/jest-junit/issues/211