### PR TITLE
Don't assume test execution failure if testExecError is null

### DIFF
--- a/__mocks__/no-failing-tests-with-testexec-null.json
+++ b/__mocks__/no-failing-tests-with-testexec-null.json
@@ -1,0 +1,65 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 1,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": null,
+      "failureMessage": null,
+      "testExecError": null,
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1489712747644,
+        "start": 1489712747524
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/test/__tests__/foo.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "foo",
+            "baz"
+          ],
+          "duration": 1,
+          "failureMessages": [],
+          "fullName": "foo baz should bar",
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should bar"
+        }
+      ],
+      "skipped": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -181,7 +181,7 @@ describe('buildJsonResults', () => {
     expect(errorSuite.testcase[1].error).toContain("Cannot find module './mult'");
   });
 
-    it('should include a failing testcase from a suite with passing testcases but  a failure from "testExec" ', () => {
+  it('should include a failing testcase from a suite with passing testcases but a failure from "testExecError" ', () => {
     const failingTestsReport = require('../__mocks__/no-failing-tests-with-testexec-failure.json');
 
     jsonResults = buildJsonResults(failingTestsReport, '/path/to/test',
@@ -190,6 +190,16 @@ describe('buildJsonResults', () => {
     const errorSuite = jsonResults.testsuites[1].testsuite[3];
     expect(slash(errorSuite.testcase[0]._attr.name)).toContain('Test execution failure');
     expect(errorSuite.testcase[1].failure).toContain("beforeAll has crashed");
+  });
+
+  it('should not include a failing testcase from a suite with passing testcases but a null value from "testExecError" ', () => {
+    const notFailingTestsReport = require('../__mocks__/no-failing-tests-with-testexec-null.json');
+
+    jsonResults = buildJsonResults(notFailingTestsReport, '/path/to/test',
+        Object.assign({}, constants.DEFAULT_OPTIONS, {}));
+
+    expect(jsonResults.testsuites[1].testsuite[2].testcase.length).toBe(1);
+    expect(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.name).toEqual('foo baz should bar');
   });
 
   it('should report empty suites as error', () => {

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -224,7 +224,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
 
     // We have all tests passed but a failure in a test hook like in the `beforeAll` method
     // Make sure we log them since Jest still reports the suite as failed
-    if (suite.testExecError !== undefined && suite.testExecError !== null) {
+    if (suite.testExecError != null) {
       const fakeTC = {
         status: testFailureStatus,
         failureMessages: [JSON.stringify(suite.testExecError)],

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -224,7 +224,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
 
     // We have all tests passed but a failure in a test hook like in the `beforeAll` method
     // Make sure we log them since Jest still reports the suite as failed
-    if (suite.testExecError !== undefined) {
+    if (suite.testExecError !== undefined && suite.testExecError !== null) {
       const fakeTC = {
         status: testFailureStatus,
         failureMessages: [JSON.stringify(suite.testExecError)],


### PR DESCRIPTION
Solves #220.

Currently, jest-junit assumes that any value other than `undefined` for `testExecError` is an error.  
However, this property can also be `null` without there being an actual problem.

This PR adds an additional check for `null`, and tests to validate it.