### PR TITLE
Add boolean support for uniqueOutputName option

### DIFF
--- a/utils/getOutputPath.js
+++ b/utils/getOutputPath.js
@@ -1,12 +1,14 @@
 const path = require('path');
 const getOptions = require('./getOptions');
 
-module.exports = (options, jestRootDir)  => {
+module.exports = (options, jestRootDir) => {
   // Override outputName and outputDirectory with outputFile if outputFile is defined
   let output = options.outputFile;
   if (!output) {
     // Set output to use new outputDirectory and fallback on original output
-    const outputName = (options.uniqueOutputName === 'true') ? getOptions.getUniqueOutputName(options.outputName) : options.outputName
+    const outputName = (options.uniqueOutputName === 'true' || options.uniqueOutputName === true)
+      ? getOptions.getUniqueOutputName(options.outputName)
+      : options.outputName
     output = getOptions.replaceRootDirInOutput(jestRootDir, options.outputDirectory);
     const finalOutput = path.join(output, outputName);
     return finalOutput;


### PR DESCRIPTION
Makes it possible to use the boolean value `true` for uniqueOutputName, _in addition to_ using the string value `"true"` to preserve support for environment variables.

Fixes #225 