### PR TITLE
Remove invalid ESC control sequence from XML output

### DIFF
--- a/__mocks__/failing-tests-with-esc.json
+++ b/__mocks__/failing-tests-with-esc.json
@@ -1,0 +1,68 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 1,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": [],
+      "failureMessage": "\u001b[1m\u001b[31m  \u001b[1m● \u001b[1mSample Failing Test › Should fail\u001b[39m\u001b[22m\n\n    foo\u001bbar\n\u001b[2m      \n      \u001b[2mat _callee$ (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:26:15)\u001b[2m\n      \u001b[2mat tryCatch (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:64:40)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.invoke [as _invoke] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:299:22)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:116:21)\u001b[2m\n      \u001b[2mat step (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:394)\u001b[2m\n      \u001b[2mat \u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:554\u001b[2m\u001b[22m\n",
+      "numFailingTests": 1,
+      "numPassingTests": 0,
+      "numPendingTests": 0,
+      "perfStats": {
+        "end": 1499904221109,
+        "start": 1499904215586
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/failing.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "Sample Failing Test",
+            "Inner",
+            "Inner Inner"
+          ],
+          "duration": 3930,
+          "failureMessages": [
+            "\u001b[1m\u001b[31m  \u001b[1m● \u001b[1mSample Failing Test › Inner › Inner Inner › Should fail\u001b[39m\u001b[22m\n\n    foo\u001bbar\n\u001b[2m      \n      \u001b[2mat _callee$ (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:26:15)\u001b[2m\n      \u001b[2mat tryCatch (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:64:40)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.invoke [as _invoke] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:299:22)\u001b[2m\n      \u001b[2mat GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (\u001b[2m\u001b[0m\u001b[36mnode_modules/regenerator-runtime/runtime.js\u001b[39m\u001b[0m\u001b[2m:116:21)\u001b[2m\n      \u001b[2mat step (\u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:394)\u001b[2m\n      \u001b[2mat \u001b[2m\u001b[0m\u001b[36mpath/to/failing.test.js\u001b[39m\u001b[0m\u001b[2m:2:554\u001b[2m\u001b[22m\n"
+          ],
+          "fullName": "Sample Failing Test Inner Inner Inner Should fail",
+          "numPassingAsserts": 0,
+          "status": "failed",
+          "title": "Should fail"
+        }
+      ],
+      "sourceMaps": {},
+      "skipped": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -27,8 +27,24 @@ const path = require('path');
 const testResultProcessor = require('../');
 
 describe('jest-junit', () => {
+  beforeEach(() => {
+    const foundKeys = Object.keys(process.env).filter(k => k.startsWith('JEST_JUNIT'));
+    if (foundKeys.length > 0) {
+      throw new Error(`process.env should not have JEST_JUNIT keys set. Found: ${foundKeys.join(', ')}`);
+    }
+  });
 
-  afterEach(() => jest.clearAllMocks())
+  afterEach(() => {
+    for (let key in process.env) {
+      if (key.startsWith('JEST_JUNIT')) {
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('should generate valid xml with default name', () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
@@ -67,6 +83,20 @@ describe('jest-junit', () => {
     expect(xmlDoc).toBeTruthy();
   });
 
+  it('should generate valid xml despite illegal characters', () => {
+    const failingTestsWithEscReport = require('../__mocks__/failing-tests-with-esc.json');
+    testResultProcessor(failingTestsWithEscReport);
+
+    // Ensure fs.writeFileSync is called
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+    // Ensure file would have been generated
+    expect(fs.writeFileSync).toHaveBeenLastCalledWith(path.resolve('junit.xml'), expect.any(String));
+
+    // Ensure generated file is valid xml
+    const xmlDoc = libxmljs.parseXml(fs.writeFileSync.mock.calls[0][1]);
+    expect(xmlDoc).toBeTruthy();
+  });
 
   it('should generate xml at the output filepath defined by JEST_JUNIT_OUTPUT_FILE', () => {
     process.env.JEST_JUNIT_OUTPUT_FILE = 'path_to_output/output_name.xml'
@@ -83,6 +113,7 @@ describe('jest-junit', () => {
   });
 
   it('should generate xml at the output filepath defined by outputFile config', () => {
+    process.env.JEST_JUNIT_OUTPUT_FILE = 'path_to_output/output_name.xml'
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
     testResultProcessor(noFailingTestsReport, {outputFile: 'path_to_output/output_name.xml' });
 

--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -35,15 +35,13 @@ describe('jest-junit', () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
+
     for (let key in process.env) {
       if (key.startsWith('JEST_JUNIT')) {
         delete process.env[key];
       }
     }
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   it('should generate valid xml with default name', () => {

--- a/index.js
+++ b/index.js
@@ -34,8 +34,12 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   // Ensure output path exists
   mkdirp.sync(path.dirname(outputPath));
 
+  // Clean ESC character, which is invalid XML and some libraries include in error messages
+  const xmlString = xml(jsonResults, { indent: '  ', declaration: true });
+  const cleanedXmlString = xmlString.replace(/\u001b/g, '');
+
   // Write data to file
-  fs.writeFileSync(outputPath, xml(jsonResults, { indent: '  ', declaration: true }));
+  fs.writeFileSync(outputPath, cleanedXmlString);
 
   // Jest 18 compatibility
   return report;

--- a/index.js
+++ b/index.js
@@ -34,12 +34,8 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   // Ensure output path exists
   mkdirp.sync(path.dirname(outputPath));
 
-  // Clean ESC character, which is invalid XML and some libraries include in error messages
-  const xmlString = xml(jsonResults, { indent: '  ', declaration: true });
-  const cleanedXmlString = xmlString.replace(/\u001b/g, '');
-
   // Write data to file
-  fs.writeFileSync(outputPath, cleanedXmlString);
+  fs.writeFileSync(outputPath, xml(jsonResults, { indent: '  ', declaration: true }));
 
   // Jest 18 compatibility
   return report;

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -74,7 +74,7 @@ const generateTestCase = function(junitOptions, suiteOptions, tc, filepath, file
     failureMessages.forEach((failure) => {
       const tagName = tc.status === testFailureStatus ? 'failure': testErrorStatus
       testCase.testcase.push({
-        [tagName]: stripAnsi(failure)
+        [tagName]: strip(failure)
       });
     })
   }
@@ -100,6 +100,11 @@ const addErrorTestResult = function (suite) {
     "numPassingAsserts": 0,
     "status": testErrorStatus
   })
+}
+
+// Strips escape codes for readability and illegal XML characters to produce valid output.
+const strip = function (str) {
+  return stripAnsi(str).replace(/\u001b/g, '');
 }
 
 module.exports = function (report, appDirectory, options, rootDir = null) {


### PR DESCRIPTION
This change forcibly deletes any occurrences of the ESC control sequence in the output XML file.

RTL emits the ESC control sequence `\u001b` or `\x1B` sometimes, and the `xml` package doesn't escape or exclude it. This is not valid XML and causes some parsers, including the one used in this package's unit tests, to fail. https://github.com/jest-community/jest-junit/issues/197 was a previous report of this.

Without this fix, the newly added test fails with an XML parse error.

![Screenshot 2022-10-21 at 12 17 02 PM](https://user-images.githubusercontent.com/83245491/197274055-33dac459-2173-4403-b1f7-ec87dfa5aa3c.png)

We could also fix in `xml` but that project appears less actively maintained, and given nobody has reported this it may not be a widespread problem worth messing with.

This also fixes leaking state between some tests.