### PR TITLE
Update docs regards regards relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reporter options should also be strings exception for suiteNameTemplate, classNa
 | Environment Variable Name | Reporter Config Name| Description | Default | Possible Injection Values
 |---|---|---|---|---|
 | `JEST_SUITE_NAME` | `suiteName` | `name` attribute of `<testsuites>` | `"jest tests"` | N/A
-| `JEST_JUNIT_OUTPUT_DIR` | `outputDirectory` | Directory to save the output. | `process.cwd()` | N/A
+| `JEST_JUNIT_OUTPUT_DIR` | `outputDirectory` | Directory to save the output. Relative path outside of project root (e.g. in monorepos) has to be prefixed with `<rootDir>` literal, e.g. `<rootDir>/../coverage` | `process.cwd()` | N/A
 | `JEST_JUNIT_OUTPUT_NAME` | `outputName` | File name for the output. | `"junit.xml"` | N/A
 | `JEST_JUNIT_OUTPUT_FILE` | `outputFile` | Fullpath for the output. If defined, `outputDirectory` and `outputName` will be overridden | `undefined` | N/A
 | `JEST_JUNIT_UNIQUE_OUTPUT_NAME` | `uniqueOutputName` | Create unique file name for the output leveraging the `outputName` as a prefix if given `${outputName}-${uuid}.xml` or a default of `junit-${uuid}.xml` if `outputName` is not specified, overrides `outputName` | `false` | N/A


### PR DESCRIPTION
readme doesn't include info about necessary `<rootDir>` literal at the beginning of `outputDirectory` when final path is outside of the project root (e.g. in monorepos)