### PR TITLE
Do not report 'testExecError' if 'noResults'

### DIFF
--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -280,7 +280,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
 
     // We have all tests passed but a failure in a test hook like in the `beforeAll` method
     // Make sure we log them since Jest still reports the suite as failed
-    if (suite.testExecError != null) {
+    if (!noResults && suite.testExecError != null) {
       const fakeTC = {
         status: testFailureStatus,
         failureMessages: [JSON.stringify(suite.testExecError)],


### PR DESCRIPTION
When there are `noResults` (and "reportTestSuiteErrors" is enabled) the resulting XML contains double test-case errors:
```
  <testsuite name="tests\failed.to.run.test.js" errors="1" failures="0" skipped="0" timestamp="1970-01-01T00:00:00" time="0" tests="0">
    <testcase classname="Test suite failed to run" name="tests\failed.to.run.test.js" time="0" file="tests\failed.to.run.test.js">
      <error>  ● Test suite failed to run

    ProtocolError: Page.captureScreenshot timed out. Increase the &apos;protocolTimeout&apos; setting in launch/connect calls for a higher timeout if needed.

      at Callback.&lt;instance_members_initializer&gt; (../node_modules/puppeteer-core/src/common/Connection.ts:66:12)
      at new Callback (../node_modules/puppeteer-core/src/common/Connection.ts:71:3)
      at CallbackRegistry.create (../node_modules/puppeteer-core/src/common/Connection.ts:127:22)
      at Connection._rawSend (../node_modules/puppeteer-core/src/common/Connection.ts:278:22)
      at CDPSessionImpl.send (../node_modules/puppeteer-core/src/common/Connection.ts:562:29)
      at CDPPage.#screenshotTask (../node_modules/puppeteer-core/src/common/Page.ts:1321:39)
      </error>
    </testcase>
    <testcase classname="Test suite failed to run" name="tests\failed.to.run.test.js" time="0" file="tests\failed.to.run.test.js">
      <failure>&quot;Page.captureScreenshot timed out. Increase the &apos;protocolTimeout&apos; setting in launch/connect calls for a higher timeout if needed.&quot;</failure>
    </testcase>
  </testsuite>
```

The second test-case is redundant and should better be suppressed.
