### PR TITLE
mark "todo" tests as skipped

### DIFF
--- a/__mocks__/no-failing-tests-with-todo.json
+++ b/__mocks__/no-failing-tests-with-todo.json
@@ -1,0 +1,82 @@
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 0,
+  "numPassedTestSuites": 1,
+  "numPassedTests": 1,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numRuntimeErrorTestSuites": 0,
+  "numTodoTests": 1,
+  "numTotalTestSuites": 1,
+  "numTotalTests": 2,
+  "snapshot": {
+    "added": 0,
+    "failure": false,
+    "filesAdded": 0,
+    "filesRemoved": 0,
+    "filesUnmatched": 0,
+    "filesUpdated": 0,
+    "matched": 0,
+    "total": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0
+  },
+  "startTime": 1489712747092,
+  "success": true,
+  "testResults": [
+    {
+      "console": null,
+      "failureMessage": null,
+      "numFailingTests": 0,
+      "numPassingTests": 1,
+      "numPendingTests": 0,
+      "numTodoTests": 1,
+      "perfStats": {
+        "end": 1489712747644,
+        "start": 1489712747524
+      },
+      "snapshot": {
+        "added": 0,
+        "fileDeleted": false,
+        "matched": 0,
+        "unchecked": 0,
+        "unmatched": 0,
+        "updated": 0
+      },
+      "testFilePath": "/path/to/test/__tests__/foo.test.js",
+      "testResults": [
+        {
+          "ancestorTitles": [
+            "foo",
+            "baz"
+          ],
+          "duration": 1,
+          "failureMessages": [],
+          "fullName": "foo baz should bar",
+          "numPassingAsserts": 0,
+          "status": "passed",
+          "title": "should bar"
+        },
+        {
+          "ancestorTitles": [
+            "foo",
+            "bar"
+          ],
+          "duration": 0,
+          "failureDetails": [],
+          "failureMessages": [],
+          "fullName": "foo bar should baz",
+          "invocations": 1,
+          "location": null,
+          "numPassingAsserts": 0,
+          "retryReasons": [],
+          "status": "todo",
+          "title": "should baz"
+        }
+      ],
+      "skipped": false
+    }
+  ],
+  "wasInterrupted": false
+}

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -447,6 +447,13 @@ describe('buildJsonResults', () => {
     expect(jsonResults.testsuites[1].testsuite[0]._attr.skipped).toBe(1);
   });
 
+  it('should include number of todo tests in testSuite total count', () => {
+    const noFailingTestsWithTodoReport = require('../__mocks__/no-failing-tests-with-todo.json');
+    jsonResults = buildJsonResults(noFailingTestsWithTodoReport, '/', constants.DEFAULT_OPTIONS);
+
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.tests).toBe(2);
+  });
+
   it('should include a skipped tag when outputting todo tests', () => {
     const noFailingTestsWithTodoReport = require('../__mocks__/no-failing-tests-with-todo.json');
     jsonResults = buildJsonResults(noFailingTestsWithTodoReport, '/', constants.DEFAULT_OPTIONS);

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -440,6 +440,25 @@ describe('buildJsonResults', () => {
     expect(jsonResults.testsuites[1].testsuite[2]['system-out']).not.toBeDefined();
   });
 
+  it('should include number of todo tests in testSuite skipped count', () => {
+    const noFailingTestsWithTodoReport = require('../__mocks__/no-failing-tests-with-todo.json');
+    jsonResults = buildJsonResults(noFailingTestsWithTodoReport, '/', constants.DEFAULT_OPTIONS);
+
+    expect(jsonResults.testsuites[1].testsuite[0]._attr.skipped).toBe(1);
+  });
+
+  it('should include a skipped tag when outputting todo tests', () => {
+    const noFailingTestsWithTodoReport = require('../__mocks__/no-failing-tests-with-todo.json');
+    jsonResults = buildJsonResults(noFailingTestsWithTodoReport, '/', constants.DEFAULT_OPTIONS);
+    expect(jsonResults.testsuites[1].testsuite[3].testcase[1]).toEqual({
+      "skipped": {
+        "_attr": {
+          "message": "todo"
+        }
+      }
+    });
+  });
+
   it("should add properties to testcase (non standard)", () => {
     const retriedTestsReport = require("../__mocks__/retried-tests.json");
     // <properties> in <testcase> is not compatible JUnit but can be consumed by some e.g. DataDog
@@ -452,7 +471,7 @@ describe('buildJsonResults', () => {
       ...constants.DEFAULT_OPTIONS,
       testCasePropertiesFile: "junitDataDogInvocationsProperties.js",
     });
-  
+
     expect(jsonResults).toMatchInlineSnapshot(`
       Object {
         "testsuites": Array [

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -102,6 +102,16 @@ const generateTestCase = function(junitOptions, suiteOptions, tc, filepath, file
     });
   }
 
+  if (tc.status === 'todo') {
+    testCase.testcase.push({
+      skipped: {
+        _attr: {
+          message: "todo"
+        }
+      }
+    });
+  }
+
   if (getGetCaseProperties !== null) {
     let junitCaseProperties = getGetCaseProperties(tc);
 
@@ -226,7 +236,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
           name: replaceVars(suiteOptions.suiteNameTemplate, suiteNameVariables),
           errors: suiteErrors,
           failures: suite.numFailingTests,
-          skipped: suite.numPendingTests,
+          skipped: suite.numPendingTests + (suite.numTodoTests ? suite.numTodoTests : 0),
           timestamp: (new Date(suite.perfStats.start)).toISOString().slice(0, -5),
           time: suiteExecutionTime,
           tests: suiteNumTests

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -226,7 +226,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
     suiteNameVariables[constants.DISPLAY_NAME_VAR] = displayName;
 
     // Add <testsuite /> properties
-    const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests;
+    const suiteNumTests = suite.numFailingTests + suite.numPassingTests + suite.numPendingTests + (suite.numTodoTests ? suite.numTodoTests : 0);
     const suiteExecutionTime = executionTime(suite.perfStats.start, suite.perfStats.end);
 
     const suiteErrors = noResults ? 1 : 0;


### PR DESCRIPTION
fix #242 

`message` attr is used to differentiate these from `it.skip` but I don't think it makes a difference; this output matches what I expect from using mocha-junit-exporter previously
