### PR TITLE
fix: remove truncation of timestamp

### DIFF
--- a/__tests__/__snapshots__/buildJsonResults.test.js.snap
+++ b/__tests__/__snapshots__/buildJsonResults.test.js.snap
@@ -22,7 +22,7 @@ Object {
             "skipped": 0,
             "tests": 1,
             "time": 0.163,
-            "timestamp": "2018-02-10T14:52:31",
+            "timestamp": "2018-02-10T14:52:31.100Z",
           },
         },
         Object {
@@ -60,7 +60,7 @@ Object {
             "skipped": 0,
             "tests": 1,
             "time": 0.073,
-            "timestamp": "2018-02-10T14:52:31",
+            "timestamp": "2018-02-10T14:52:31.274Z",
           },
         },
         Object {

--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -475,7 +475,7 @@ describe('buildJsonResults', () => {
                   "skipped": 0,
                   "tests": 1,
                   "time": 0.12,
-                  "timestamp": "2017-03-17T01:05:47",
+                  "timestamp": "2017-03-17T01:05:47.524Z",
                 },
               },
               Object {

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -227,7 +227,7 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
           errors: suiteErrors,
           failures: suite.numFailingTests,
           skipped: suite.numPendingTests,
-          timestamp: (new Date(suite.perfStats.start)).toISOString().slice(0, -5),
+          timestamp: (new Date(suite.perfStats.start)).toISOString(),
           time: suiteExecutionTime,
           tests: suiteNumTests
         }


### PR DESCRIPTION
I was taking a look at the JUnit XML output and I noticed that the timestamp on the testsuite element was missing a timezone specification. I looked at the code and noticed that the end of the timestamp was being truncated. This PR removes that truncation in order to retain the timezone information. 