### PR TITLE
chore: replace strip-ansi, mkdirp, uuid with Node.js native APIs

### DIFF
--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -1,20 +1,11 @@
 'use strict';
 
-jest.mock('mkdirp', () => {
-  return Object.assign(
-    {},
-    jest.requireActual('mkdirp'),
-    {
-      sync: jest.fn()
-    }
-  )
-});
-
 jest.mock('fs', () => {
   return Object.assign(
     {},
     jest.requireActual('fs'),
     {
+      mkdirSync: jest.fn(),
       writeFileSync: jest.fn()
     }
   )

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const xml = require('xml');
-const mkdirp = require('mkdirp');
 const fs = require('fs');
 const path = require('path');
 
@@ -32,7 +31,7 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
   let outputPath = getOutputPath(options, jestRootDir);
 
   // Ensure output path exists
-  mkdirp.sync(path.dirname(outputPath));
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
   // Write data to file
   fs.writeFileSync(outputPath, xml(jsonResults, { indent: '  ', declaration: true }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "16.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "mkdirp": "^1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
         "xml": "^1.0.1"
       },
       "devDependencies": {
@@ -55,6 +52,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1491,6 +1489,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1693,6 +1692,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3300,16 +3300,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3845,6 +3835,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4110,13 +4101,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "mkdirp": "^1.0.4",
-    "strip-ansi": "^6.0.1",
-    "uuid": "^8.3.2",
     "xml": "^1.0.1"
   },
   "devDependencies": {

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stripAnsi = require('strip-ansi');
+const { stripVTControlCharacters } = require('node:util');
 const constants = require('../constants/index');
 const path = require('path');
 const fs = require('fs');
@@ -143,7 +143,7 @@ const addErrorTestResult = function (suite) {
 
 // Strips escape codes for readability and illegal XML characters to produce valid output.
 const strip = function (str) {
-  return stripAnsi(str).replace(/\u001b/g, '');
+  return stripVTControlCharacters(str).replace(/\u001b/g, '');
 }
 
 module.exports = function (report, appDirectory, options, rootDir = null) {

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const { v1: uuid } = require('uuid');
+const { randomUUID } = require('node:crypto');
 
 const constants = require('../constants/index');
 
@@ -60,7 +60,7 @@ function replaceRootDirInOutput(rootDir, output) {
 
 function getUniqueOutputName(outputName) {
   const outputPrefix = outputName ? outputName : 'junit'
-  return `${outputPrefix}-${uuid()}.xml`
+  return `${outputPrefix}-${randomUUID()}.xml`
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Replace `strip-ansi` with `util.stripVTControlCharacters` (available since Node 16.11)
- Replace `mkdirp` with `fs.mkdirSync` using `{ recursive: true }`
- Replace `uuid` (v1) with `crypto.randomUUID` (v4)

Reduces runtime dependencies from 4 to 1 (only `xml` remains).

## Changes

- `utils/buildJsonResults.js` — `require('strip-ansi')` → `require('node:util').stripVTControlCharacters`
- `utils/getOptions.js` — `require('uuid').v1` → `require('node:crypto').randomUUID`
- `index.js` — Remove `mkdirp` import, use `fs.mkdirSync` with `{ recursive: true }`
- `package.json` — Remove `strip-ansi`, `mkdirp`, `uuid` from dependencies
- `package-lock.json` — Regenerated
- `__tests__/testResultProcessor.test.js` — Update mock to target `fs.mkdirSync` instead of `mkdirp.sync`

## Notes

- All three replacements are safe since jest-junit requires `node >= 20.0.0`
- `uniqueOutputName` now generates v4 UUIDs (random) instead of v1 (timestamp-based). No functional impact — UUIDs are only used for filename uniqueness.
- The existing `.replace(/\u001b/g, '')` safety net in the `strip()` function is preserved

## Testing

All 51 tests pass with `NODE_OPTIONS="--experimental-vm-modules" npm test`.

Addresses #251