### PR TITLE
Upgrade uuid to 14.0.0

### DIFF
--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -41,14 +41,14 @@ describe('getOptions', () => {
 describe('getUniqueOutputName', () =>{
   const defaultPrefix = 'junit'
 
-  it(`should return default ${defaultPrefix} value if given no preferred prefix`, () => {
-    const uniqueOutput = getOptions.getUniqueOutputName()
+  it(`should return default ${defaultPrefix} value if given no preferred prefix`, async () => {
+    const uniqueOutput = await getOptions.getUniqueOutputName()
     expect(uniqueOutput).toContain(defaultPrefix)
   })
 
-  it(`should return apply custom prefix value if given prefix`, () => {
+  it(`should return apply custom prefix value if given prefix`, async () => {
     const customPrefix = "foo"
-    const uniqueOutput = getOptions.getUniqueOutputName(customPrefix)
+    const uniqueOutput = await getOptions.getUniqueOutputName(customPrefix)
     expect(uniqueOutput).not.toContain(defaultPrefix)
     expect(uniqueOutput).toContain(customPrefix)
   })

--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -43,9 +43,9 @@ describe('jest-junit', () => {
     }
   });
 
-  it('should generate valid xml with default name', () => {
+  it('should generate valid xml with default name', async () => {
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    testResultProcessor(noFailingTestsReport);
+    await testResultProcessor(noFailingTestsReport);
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -54,14 +54,14 @@ describe('jest-junit', () => {
     expect(fs.writeFileSync).toHaveBeenLastCalledWith(path.resolve('junit.xml'), expect.any(String));
   });
 
-  it('should generate valid xml with unique name', () => {
+  it('should generate valid xml with unique name', async () => {
     process.env.JEST_JUNIT_UNIQUE_OUTPUT_NAME = 'true'
 
     const outputPrefix = "foo"
 
     process.env.JEST_JUNIT_OUTPUT_NAME = outputPrefix;
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    testResultProcessor(noFailingTestsReport);
+    await testResultProcessor(noFailingTestsReport);
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -72,9 +72,9 @@ describe('jest-junit', () => {
     expect(fs.writeFileSync).toHaveBeenLastCalledWith(expect.stringMatching(expectedOutputRegex), expect.any(String));
   });
 
-  it('should generate valid xml despite illegal characters', () => {
+  it('should generate valid xml despite illegal characters', async () => {
     const failingTestsWithEscReport = require('../__mocks__/failing-tests-with-esc.json');
-    testResultProcessor(failingTestsWithEscReport);
+    await testResultProcessor(failingTestsWithEscReport);
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -83,10 +83,10 @@ describe('jest-junit', () => {
     expect(fs.writeFileSync).toHaveBeenLastCalledWith(path.resolve('junit.xml'), expect.any(String));
   });
 
-  it('should generate xml at the output filepath defined by JEST_JUNIT_OUTPUT_FILE', () => {
+  it('should generate xml at the output filepath defined by JEST_JUNIT_OUTPUT_FILE', async () => {
     process.env.JEST_JUNIT_OUTPUT_FILE = 'path_to_output/output_name.xml'
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    testResultProcessor(noFailingTestsReport);
+    await testResultProcessor(noFailingTestsReport);
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -97,10 +97,10 @@ describe('jest-junit', () => {
     );
   });
 
-  it('should generate xml at the output filepath defined by outputFile config', () => {
+  it('should generate xml at the output filepath defined by outputFile config', async () => {
     process.env.JEST_JUNIT_OUTPUT_FILE = 'path_to_output/output_name.xml'
     const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
-    testResultProcessor(noFailingTestsReport, {outputFile: 'path_to_output/output_name.xml' });
+    await testResultProcessor(noFailingTestsReport, {outputFile: 'path_to_output/output_name.xml' });
 
     // Ensure fs.writeFileSync is called
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const getOutputPath = require('./utils/getOutputPath');
 // append to result
 const consoleBuffer = {};
 
-const processor = (report, reporterOptions = {}, jestRootDir = null) => {
+const processor = async (report, reporterOptions = {}, jestRootDir = null) => {
   // If jest-junit is used as a reporter allow for reporter options
   // to be used. Env and package.json will override.
   const options = getOptions.options(reporterOptions);
@@ -29,7 +29,7 @@ const processor = (report, reporterOptions = {}, jestRootDir = null) => {
     jestRootDir
   );
 
-  let outputPath = getOutputPath(options, jestRootDir);
+  let outputPath = await getOutputPath(options, jestRootDir);
 
   // Ensure output path exists
   mkdirp.sync(path.dirname(outputPath));
@@ -79,8 +79,8 @@ function JestJUnit (globalConfig, options) {
     }
   };
 
-  this.onRunComplete = (contexts, results) => {
-    processor(results, this._options, this._globalConfig.rootDir);
+  this.onRunComplete = async (contexts, results) => {
+    await processor(results, this._options, this._globalConfig.rootDir);
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
+        "uuid": "^14.0.0",
         "xml": "^1.0.1"
       },
       "devDependencies": {
@@ -4113,10 +4113,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "mkdirp": "^1.0.4",
     "strip-ansi": "^6.0.1",
-    "uuid": "^8.3.2",
+    "uuid": "^14.0.0",
     "xml": "^1.0.1"
   },
   "devDependencies": {

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -2,11 +2,18 @@
 
 const path = require('path');
 const fs = require('fs');
-const { v1: uuid } = require('uuid');
 
 const constants = require('../constants/index');
 
 const { replaceRootDirInPath } = require('./replaceRootDirInPath');
+
+let uuidV1Promise;
+function loadUuidV1() {
+  if (!uuidV1Promise) {
+    uuidV1Promise = import('uuid').then((mod) => mod.v1);
+  }
+  return uuidV1Promise;
+}
 
 function getEnvOptions() {
   const options = {};
@@ -58,9 +65,10 @@ function replaceRootDirInOutput(rootDir, output) {
   return rootDir !== null ? replaceRootDirInPath(rootDir, output) : output;
 }
 
-function getUniqueOutputName(outputName) {
+async function getUniqueOutputName(outputName) {
+  const v1 = await loadUuidV1();
   const outputPrefix = outputName ? outputName : 'junit'
-  return `${outputPrefix}-${uuid()}.xml`
+  return `${outputPrefix}-${v1()}.xml`
 }
 
 module.exports = {

--- a/utils/getOutputPath.js
+++ b/utils/getOutputPath.js
@@ -1,12 +1,12 @@
 const path = require('path');
 const getOptions = require('./getOptions');
 
-module.exports = (options, jestRootDir)  => {
+module.exports = async (options, jestRootDir)  => {
   // Override outputName and outputDirectory with outputFile if outputFile is defined
   let output = options.outputFile;
   if (!output) {
     // Set output to use new outputDirectory and fallback on original output
-    const outputName = (options.uniqueOutputName === 'true') ? getOptions.getUniqueOutputName(options.outputName) : options.outputName
+    const outputName = (options.uniqueOutputName === 'true') ? await getOptions.getUniqueOutputName(options.outputName) : options.outputName
     output = getOptions.replaceRootDirInOutput(jestRootDir, options.outputDirectory);
     const finalOutput = path.join(output, outputName);
     return finalOutput;


### PR DESCRIPTION
## Summary
- Bump `uuid` from `^8.3.2` to `^14.0.0`.
- `uuid` v14 is shipped as a pure ESM package (no CommonJS export), so `require('uuid')` no longer works. Switched to a lazy dynamic `import('uuid')` for the `v1` generator and propagated `async` through `getUniqueOutputName` -> `getOutputPath` -> the reporter's `processor` / `onRunComplete`.
- Updated tests to `await` the now-async APIs.

## Test plan
- [x] `NODE_OPTIONS=--experimental-vm-modules npm test` -- 4 suites, 51 tests pass, 2 snapshots pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
