### PR TITLE
fix: expand <rootDir> in filePathPrefix

### DIFF
--- a/__tests__/buildJsonResults.test.js
+++ b/__tests__/buildJsonResults.test.js
@@ -400,6 +400,21 @@ describe('buildJsonResults', () => {
     expect(slash(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.file)).toBe('packages/foobar/path/to/test/__tests__/foo.test.js');
   });
 
+  it('should expand <rootDir> in filePathPrefix', () => {
+    // Ignore junit errors for this attribute
+    // It is added for circle-ci and is known to not generate
+    // jenkins-compatible junit
+    ignoreJunitErrors = true;
+
+    const noFailingTestsReport = require('../__mocks__/no-failing-tests.json');
+    jsonResults = buildJsonResults(noFailingTestsReport, '/',
+      Object.assign({}, constants.DEFAULT_OPTIONS, {
+        addFileAttribute: "true",
+        filePathPrefix: "<rootDir>/packages/foobar"
+      }), '/tmp/project');
+    expect(slash(jsonResults.testsuites[1].testsuite[2].testcase[0]._attr.file)).toBe('/tmp/project/packages/foobar/path/to/test/__tests__/foo.test.js');
+  });
+
   it('should show output of console if includeConsoleOutput is true', () => {
     const reportWithConsoleOutput = require('../__mocks__/test-with-console-output.json');
     jsonResults = buildJsonResults(reportWithConsoleOutput, '/',

--- a/utils/buildJsonResults.js
+++ b/utils/buildJsonResults.js
@@ -200,8 +200,10 @@ module.exports = function (report, appDirectory, options, rootDir = null) {
       addErrorTestResult(suite);
     }
 
+    const filePathPrefix = replaceRootDirInOutput(rootDir, suiteOptions.filePathPrefix);
+
     // Build variables for suite name
-    const filepath = path.join(suiteOptions.filePathPrefix, path.relative(appDirectory, suite.testFilePath));
+    const filepath = path.join(filePathPrefix, path.relative(appDirectory, suite.testFilePath));
     const filename = path.basename(filepath);
     const suiteTitle = suite.testResults[0].ancestorTitles[0];
     const displayName = typeof suite.displayName === 'object'


### PR DESCRIPTION
## Summary
- expand <rootDir> in filePathPrefix before joining test paths
- add coverage for <rootDir> expansion

## Test Plan
- NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/buildJsonResults.test.js

Closes #256