### PR TITLE
refactor: replace uuid with native crypto.randomUUID()

### DIFF
--- a/__tests__/getOptions.test.js
+++ b/__tests__/getOptions.test.js
@@ -41,14 +41,14 @@ describe('getOptions', () => {
 describe('getUniqueOutputName', () =>{
   const defaultPrefix = 'junit'
 
-  it(`should return default ${defaultPrefix} value if given no preferred prefix`, async () => {
-    const uniqueOutput = await getOptions.getUniqueOutputName()
+  it(`should return default ${defaultPrefix} value if given no preferred prefix`, () => {
+    const uniqueOutput = getOptions.getUniqueOutputName()
     expect(uniqueOutput).toContain(defaultPrefix)
   })
 
-  it(`should return apply custom prefix value if given prefix`, async () => {
+  it(`should return apply custom prefix value if given prefix`, () => {
     const customPrefix = "foo"
-    const uniqueOutput = await getOptions.getUniqueOutputName(customPrefix)
+    const uniqueOutput = getOptions.getUniqueOutputName(customPrefix)
     expect(uniqueOutput).not.toContain(defaultPrefix)
     expect(uniqueOutput).toContain(customPrefix)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "jest-junit",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-junit",
-      "version": "16.0.0",
+      "version": "17.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
-        "uuid": "^14.0.0",
         "xml": "^1.0.1"
       },
       "devDependencies": {
@@ -4110,19 +4109,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "mkdirp": "^1.0.4",
     "strip-ansi": "^6.0.1",
-    "uuid": "^14.0.0",
     "xml": "^1.0.1"
   },
   "devDependencies": {

--- a/utils/getOptions.js
+++ b/utils/getOptions.js
@@ -6,14 +6,7 @@ const fs = require('fs');
 const constants = require('../constants/index');
 
 const { replaceRootDirInPath } = require('./replaceRootDirInPath');
-
-let uuidV1Promise;
-function loadUuidV1() {
-  if (!uuidV1Promise) {
-    uuidV1Promise = import('uuid').then((mod) => mod.v1);
-  }
-  return uuidV1Promise;
-}
+const { randomUUID } = require('crypto');
 
 function getEnvOptions() {
   const options = {};
@@ -65,10 +58,9 @@ function replaceRootDirInOutput(rootDir, output) {
   return rootDir !== null ? replaceRootDirInPath(rootDir, output) : output;
 }
 
-async function getUniqueOutputName(outputName) {
-  const v1 = await loadUuidV1();
+function getUniqueOutputName(outputName) {
   const outputPrefix = outputName ? outputName : 'junit'
-  return `${outputPrefix}-${v1()}.xml`
+  return `${outputPrefix}-${randomUUID()}.xml`
 }
 
 module.exports = {

--- a/utils/getOutputPath.js
+++ b/utils/getOutputPath.js
@@ -6,7 +6,7 @@ module.exports = async (options, jestRootDir)  => {
   let output = options.outputFile;
   if (!output) {
     // Set output to use new outputDirectory and fallback on original output
-    const outputName = (options.uniqueOutputName === 'true') ? await getOptions.getUniqueOutputName(options.outputName) : options.outputName
+    const outputName = (options.uniqueOutputName === 'true') ? getOptions.getUniqueOutputName(options.outputName) : options.outputName
     output = getOptions.replaceRootDirInOutput(jestRootDir, options.outputDirectory);
     const finalOutput = path.join(output, outputName);
     return finalOutput;


### PR DESCRIPTION
Remove the uuid dependency in favor of the built-in crypto.randomUUID(), which produces a cryptographically secure v4 UUID. This reduces supply-chain risk by eliminating an external dependency. The change is safe because Node.js >= 20 is already required, where crypto.randomUUID() is a stable global.