### PR TITLE
Replace mkdirp with native mkdir

### DIFF
--- a/__tests__/testResultProcessor.test.js
+++ b/__tests__/testResultProcessor.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-jest.mock('mkdirp', () => {
+jest.mock('node:fs/promises', () => {
   return Object.assign(
     {},
-    jest.requireActual('mkdirp'),
+    jest.requireActual('node:fs/promises'),
     {
-      sync: jest.fn()
+      mkdir: jest.fn()
     }
   )
 });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const xml = require('xml');
-const mkdirp = require('mkdirp');
+const { mkdir } = require('node:fs/promises');
 const fs = require('fs');
 const path = require('path');
 
@@ -32,7 +32,7 @@ const processor = async (report, reporterOptions = {}, jestRootDir = null) => {
   let outputPath = await getOutputPath(options, jestRootDir);
 
   // Ensure output path exists
-  mkdirp.sync(path.dirname(outputPath));
+  await mkdir(path.dirname(outputPath), { recursive: true });
 
   // Write data to file
   fs.writeFileSync(outputPath, xml(jsonResults, { indent: '  ', declaration: true }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "jest-junit",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-junit",
-      "version": "16.0.0",
+      "version": "17.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
         "uuid": "^14.0.0",
         "xml": "^1.0.1"
@@ -3298,16 +3297,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "mkdirp": "^1.0.4",
     "strip-ansi": "^6.0.1",
     "uuid": "^14.0.0",
     "xml": "^1.0.1"


### PR DESCRIPTION
Since node 10 there is native mkdir with a recursive option. Use the native mkdir and remove the external mkdirp dependency.